### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,50 @@
 All notable changes to the Matchbox plugin will be documented in this file.
 
 
-## [0.8.5-beta] - 2024-12-19 
+## [0.8.6-beta] - Latest
+
+### Code Quality & Documentation
+- **Code Cleanup**: Comprehensive codebase cleanup and refactoring
+  - Removed non-essential comments ("NEW:", "Note:", "Edge case:", etc.)
+  - Removed obsolete TODO comments
+  - Cleaned up verbose inline comments that didn't add value
+  - Removed redundant code and dead branches
+- **Documentation Improvements**: Enhanced code documentation
+  - Added comprehensive JavaDoc to main plugin class (Matchbox)
+  - Added detailed JavaDoc to enums (GamePhase, Role)
+  - Improved class-level documentation (SessionGameContext, etc.)
+  - Added proper @Deprecated annotations with migration guidance
+  - Enhanced field documentation with clear descriptions
+- **Bug Fixes**: Fixed logic issues and potential bugs
+  - Fixed redundant vote count update logic in VoteManager (removed unreachable code)
+  - Removed dead code branches that could never execute
+  - Improved code clarity and maintainability
+
+### Fixed
+- **Double Round Messages**: Fixed issue where players received two round messages (round 1 and round 2) when starting a game
+  - Removed duplicate `startNewRound()` call in `GameManager.startRound()`
+  - Round counter now correctly starts at 1 instead of jumping to 2
+- **Session Cleanup**: Fixed issue where sessions remained in the list after game ended
+  - Sessions are now fully removed from SessionManager when game ends (complete termination)
+  - Updated `list` command to filter out inactive sessions
+  - No need to use `stop` command for full session termination
+- **Spark Name Announcement**: Fixed win message to include the Spark's player name
+  - Win messages now show: `"[PlayerName] (Spark) wins!"` instead of just "Spark wins!"
+  - Applies to all Spark win conditions
+- **Voting Paper Activation**: Enhanced voting paper interaction support
+  - Added left-click support in inventory (previously only right-click)
+  - Right-click in inventory still works
+  - Right-click when held in main hand still works (via VoteItemListener)
+  - Players can now vote using any of these methods
+
+### Changed
+- **Session Termination**: Sessions are now fully removed when game ends, not just marked inactive
+  - Ensures complete cleanup and prevents memory leaks
+  - Sessions automatically removed from SessionManager on game end
+
+---
+
+## [0.8.5-beta]  
 
 ### Added
 - **Parallel Game Sessions**: Multiple games can now run simultaneously without interfering with each other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to the Matchbox plugin will be documented in this file.
+
+
+## [0.8.5-beta] - 2024-12-19 
+
+### Added
+- **Parallel Game Sessions**: Multiple games can now run simultaneously without interfering with each other
+- **Session Context Management**: Introduced `SessionGameContext` to encapsulate all game state per session
+- **Edge Case Handling**: Added comprehensive edge case handling for parallel sessions
+  - Players cannot join multiple sessions simultaneously
+  - Automatic cleanup of orphaned contexts
+  - Session validation before context creation
+  - Emergency cleanup on plugin disable
+- **Memory Leak Prevention**: Enhanced session termination and cleanup
+  - Sessions automatically end when all players leave
+  - Sessions automatically end when game ends and winner is announced
+  - Proper cleanup of timers, tasks, and player backups
+  - Emergency cleanup method for plugin shutdown
+- **Code Refactoring**: Refactored `GameManager` into smaller, focused classes
+  - `GameLifecycleManager`: Handles game and round lifecycle (fully integrated)
+  - `PlayerActionHandler`: Handles player actions (swipe, cure, vote) (fully integrated)
+
+### Fixed
+- **Timer Reset Bug**: Fixed issue where timers didn't reset when phases were force-skipped
+  - Swipe timer now properly cancels when discussion phase starts
+  - Discussion timer now properly cancels when voting phase starts
+  - Voting timer now properly cancels when round ends
+- **Memory Leak**: Fixed issue where sessions remained active after game end
+  - Sessions now properly marked inactive when game ends
+  - Sessions now properly removed when empty
+  - Player backups now properly cleaned up
+- **Chat Listener**: Fixed chat listener to work with parallel sessions
+  - Now correctly identifies which session a player is in
+  - Uses session-specific phase manager
+- **Player Join Validation**: Added validation to prevent players from joining:
+  - Full sessions (7 players)
+  - Already started games
+  - Multiple sessions simultaneously
+
+### Changed
+- **Command Permissions**: Updated command access
+  - Normal players can use: `join`, `leave`, `list`
+  - Operators only: `start`, `setspawn`, `setdiscussion`, `begin`, `stop`, `delete`, `debug`
+- **Phase Handlers**: Refactored to support parallel sessions
+  - Each phase handler now manages tasks per session using `Map<String, BukkitTask>`
+  - Timers can be cancelled for specific sessions without affecting others
+- **GameManager**: Major refactoring for parallel session support
+  - Now manages `Map<String, SessionGameContext>` instead of single game state
+  - Methods now take `sessionName` parameter or derive it from player UUID
+  - Added helper methods: `getContext()`, `getContextForPlayer()`, `canPlayerJoinSession()`
+  - Added `emergencyCleanup()` for plugin shutdown
+- **Code Organization**: Refactored into smaller, focused classes
+  - `GameLifecycleManager` fully integrated - handles game/round lifecycle management
+  - `PlayerActionHandler` fully integrated - handles player actions (swipe, cure, vote)
+  - `GameManager` significantly reduced in size and complexity
+
+### Security
+- Added validation to prevent context creation for non-existent sessions
+- Added checks to prevent players from being in multiple sessions
+
+---
+
+## [0.8-beta] - Previous Version
+
+### Features
+- Core game mechanics (swipe, discussion, voting phases)
+- Role assignment (Spark, Medic, Innocent)
+- Inventory system with paper-based abilities
+- Win condition detection
+- Player backup and restore
+- Session management
+

--- a/README.md
+++ b/README.md
@@ -196,11 +196,12 @@ Aliases: `/mb` or `/mbox` work instead of `/matchbox`
 - Hologram Chat: Chat appears as holograms during swipe phase (no chat log)
 - Visual Effects: All effects are recording-safe and don't reveal roles
 
-### Current Features (v0.8-beta)
+### Current Features (v0.8.5-beta)
 
-**Status: Beta Testing Stage** - All core features are implemented and tested. Ready for beta testing!
+**Status: Beta Testing Stage** - All core features are implemented and tested. Parallel sessions now supported!
 
 **Fully Implemented:**
+- ✅ **Parallel Game Sessions**: Multiple games can run simultaneously without interference
 - ✅ Session management system (create, join, leave, start, stop)
 - ✅ Role assignment (Spark, Medic, Innocent) with proper distribution
 - ✅ Automatic inventory system with identical layouts for all players
@@ -225,13 +226,16 @@ Aliases: `/mb` or `/mbox` work instead of `/matchbox`
 - ✅ Player state backup and restore (inventory, location, health, etc.)
 - ✅ Session cleanup on game end (prevents new rounds after game ends)
 - ✅ Comprehensive defensive programming and error handling
-- ✅ Edge case handling (offline players, 1-2 player games, etc.)
+- ✅ Edge case handling (offline players, 1-2 player games, parallel sessions, etc.)
+- ✅ Memory leak prevention (automatic session termination, proper cleanup)
 
-**Recent Bug Fixes (Beta):**
-- ✅ Fixed: Hunter Vision no longer affects nametag visibility (only shows particles)
-- ✅ Fixed: Nametags properly restored after Hunter Vision ability expires
-- ✅ Fixed: Sessions properly marked inactive when games end naturally
-- ✅ Fixed: New rounds no longer start automatically after game ends
+**Recent Bug Fixes (v0.8.5-beta):**
+- ✅ Fixed: Timer reset bug - timers now properly cancel when phases are force-skipped
+- ✅ Fixed: Memory leak - sessions now properly terminate when game ends or all players leave
+- ✅ Fixed: Chat listener now works correctly with parallel sessions
+- ✅ Fixed: Players can no longer join multiple sessions simultaneously
+- ✅ Fixed: Sessions properly validate before context creation
+- ✅ Fixed: Emergency cleanup on plugin disable prevents orphaned contexts
 
 ### Planned for Full Release (v1.0)
 
@@ -280,6 +284,14 @@ Aliases: `/mb` or `/mbox` work instead of `/matchbox`
 - **Spectator Teleport**: Eliminated players enter spectator mode but aren't teleported to a spectator area yet (planned for v1.0)
 - **Hunter Vision**: Uses particles for visibility (works perfectly, but ProtocolLib integration would enable true single-player glow effect - optional enhancement)
 
+## Parallel Sessions
+
+Starting with v0.8.5-beta, Matchbox supports multiple simultaneous game sessions. This means:
+- Multiple groups can play different games at the same time
+- Each session has its own game state, timers, and players
+- Sessions are completely isolated from each other
+- Memory is properly managed with automatic cleanup
+
 ---
 
 ## Reporting Issues
@@ -300,7 +312,7 @@ This project is under the MIT license.
 ## Credits
 
 Developer: OhACD  
-Version: 0.8-beta  
+Version: 0.8.5-beta  
 Minecraft API: 1.21
 
 ---

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.ohacd'
-version = '0.8-beta'
+version = '0.8.5-beta'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -13,6 +13,8 @@ import com.ohacd.matchbox.game.utils.VoteItemListener;
 import com.ohacd.matchbox.game.utils.VotePaperListener;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.Set;
+
 public final class Matchbox extends JavaPlugin {
     private static Matchbox instance;
     private HologramManager hologramManager;
@@ -59,9 +61,25 @@ public final class Matchbox extends JavaPlugin {
         // Plugin shutdown logic
         getLogger().info("Disabling Matchbox plugin...");
         
-        // End any active game first (this cancels all tasks)
+        // End all active games first (this cancels all tasks)
         if (gameManager != null) {
-            gameManager.endGame();
+            try {
+                Set<String> activeSessions = gameManager.getActiveSessionNames();
+                getLogger().info("Ending " + activeSessions.size() + " active game session(s)...");
+                for (String sessionName : activeSessions) {
+                    try {
+                        gameManager.endGame(sessionName);
+                    } catch (Exception e) {
+                        getLogger().warning("Error ending session " + sessionName + ": " + e.getMessage());
+                    }
+                }
+                
+                // Emergency cleanup in case anything was missed
+                gameManager.emergencyCleanup();
+            } catch (Exception e) {
+                getLogger().severe("Error during plugin shutdown cleanup: " + e.getMessage());
+                e.printStackTrace();
+            }
         }
         
         // Clear all holograms

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -15,6 +15,10 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Set;
 
+/**
+ * Main plugin class for Matchbox - a social deduction game for Minecraft.
+ * Supports parallel game sessions with up to 7 players each.
+ */
 public final class Matchbox extends JavaPlugin {
     private static Matchbox instance;
     private HologramManager hologramManager;
@@ -23,32 +27,30 @@ public final class Matchbox extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        // Plugin startup logic
         instance = this;
         this.hologramManager = new HologramManager(this);
         this.gameManager = new GameManager(this, hologramManager);
         this.sessionManager = new SessionManager();
 
-        // Register events
+        // Register event listeners
         getServer().getPluginManager().registerEvents(new ChatListener(hologramManager, gameManager), this);
         getServer().getPluginManager().registerEvents(new HitRevealListener(gameManager, hologramManager, gameManager.getInventoryManager()), this);
         getServer().getPluginManager().registerEvents(new GameItemProtectionListener(), this);
-        // Register swipe ability listeners
+        
+        // Register ability listeners
         getServer().getPluginManager().registerEvents(new com.ohacd.matchbox.game.ability.SwipeActivationListener(gameManager, this), this);
         getServer().getPluginManager().registerEvents(new com.ohacd.matchbox.game.ability.SwipeHitListener(gameManager), this);
-        // Register spark vision listener
         getServer().getPluginManager().registerEvents(new com.ohacd.matchbox.game.ability.SparkVisionListener(gameManager), this);
-        // Register medic ability listeners
-        // Healing Touch (Cure) - slot 9
         getServer().getPluginManager().registerEvents(new com.ohacd.matchbox.game.ability.MedicAbilityListener(gameManager, this), this);
         getServer().getPluginManager().registerEvents(new com.ohacd.matchbox.game.ability.MedicHitListener(gameManager), this);
-        // Healing Sight - slot 8
         getServer().getPluginManager().registerEvents(new com.ohacd.matchbox.game.ability.MedicSightListener(gameManager), this);
-        // Voting listeners
+        
+        // Register voting listeners
         getServer().getPluginManager().registerEvents(new VoteItemListener(gameManager), this);
         getServer().getPluginManager().registerEvents(new VotePaperListener(gameManager), this);
         getServer().getPluginManager().registerEvents(new PlayerQuitListener(gameManager), this);
-        // Register command
+        
+        // Register command handler
         MatchboxCommand commandHandler = new MatchboxCommand(this, sessionManager, gameManager);
         getCommand("matchbox").setExecutor(commandHandler);
         getCommand("matchbox").setTabCompleter(commandHandler);
@@ -58,7 +60,6 @@ public final class Matchbox extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        // Plugin shutdown logic
         getLogger().info("Disabling Matchbox plugin...");
         
         // End all active games first (this cancels all tasks)
@@ -74,7 +75,6 @@ public final class Matchbox extends JavaPlugin {
                     }
                 }
                 
-                // Emergency cleanup in case anything was missed
                 gameManager.emergencyCleanup();
             } catch (Exception e) {
                 getLogger().severe("Error during plugin shutdown cleanup: " + e.getMessage());
@@ -82,12 +82,10 @@ public final class Matchbox extends JavaPlugin {
             }
         }
         
-        // Clear all holograms
         if (hologramManager != null) {
             hologramManager.clearAll();
         }
 
-        // Restore all nametags before shutdown
         getLogger().info("Restoring all nametags...");
         NameTagManager.restoreAllNameTags();
 

--- a/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
+++ b/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Contains all game state and managers for a single active game session.
  * This allows multiple games to run in parallel without interfering with each other.
+ * Each session maintains its own game state, phase manager, vote manager, and ability windows.
  */
 public class SessionGameContext {
     private final String sessionName;
@@ -25,12 +26,16 @@ public class SessionGameContext {
     private final WinConditionChecker winConditionChecker;
     private final VoteManager voteManager;
     
-    // Per-session player data
+    /** Maps player UUID to expiry timestamp for active swipe windows */
     private final Map<UUID, Long> activeSwipeWindow = new ConcurrentHashMap<>();
+    
+    /** Maps player UUID to expiry timestamp for active cure windows */
     private final Map<UUID, Long> activeCureWindow = new ConcurrentHashMap<>();
     
-    // Current round data for this session
+    /** Discussion location for the current round */
     private Location currentDiscussionLocation;
+    
+    /** Spawn locations for the current round */
     private List<Location> currentSpawnLocations;
     
     public SessionGameContext(Plugin plugin, String sessionName) {

--- a/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
+++ b/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
@@ -1,0 +1,107 @@
+package com.ohacd.matchbox.game;
+
+import com.ohacd.matchbox.game.phase.PhaseManager;
+import com.ohacd.matchbox.game.role.RoleAssigner;
+import com.ohacd.matchbox.game.state.GameState;
+import com.ohacd.matchbox.game.vote.VoteManager;
+import com.ohacd.matchbox.game.win.WinConditionChecker;
+import org.bukkit.Location;
+import org.bukkit.plugin.Plugin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Contains all game state and managers for a single active game session.
+ * This allows multiple games to run in parallel without interfering with each other.
+ */
+public class SessionGameContext {
+    private final String sessionName;
+    private final GameState gameState;
+    private final PhaseManager phaseManager;
+    private final RoleAssigner roleAssigner;
+    private final WinConditionChecker winConditionChecker;
+    private final VoteManager voteManager;
+    
+    // Per-session player data
+    private final Map<UUID, Long> activeSwipeWindow = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> activeCureWindow = new ConcurrentHashMap<>();
+    
+    // Current round data for this session
+    private Location currentDiscussionLocation;
+    private List<Location> currentSpawnLocations;
+    
+    public SessionGameContext(Plugin plugin, String sessionName) {
+        if (sessionName == null || sessionName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Session name cannot be null or empty");
+        }
+        this.sessionName = sessionName;
+        this.gameState = new GameState();
+        this.phaseManager = new PhaseManager(plugin);
+        this.roleAssigner = new RoleAssigner(gameState);
+        this.winConditionChecker = new WinConditionChecker(gameState);
+        this.voteManager = new VoteManager(gameState);
+    }
+    
+    public String getSessionName() {
+        return sessionName;
+    }
+    
+    public GameState getGameState() {
+        return gameState;
+    }
+    
+    public PhaseManager getPhaseManager() {
+        return phaseManager;
+    }
+    
+    public RoleAssigner getRoleAssigner() {
+        return roleAssigner;
+    }
+    
+    public WinConditionChecker getWinConditionChecker() {
+        return winConditionChecker;
+    }
+    
+    public VoteManager getVoteManager() {
+        return voteManager;
+    }
+    
+    public Map<UUID, Long> getActiveSwipeWindow() {
+        return activeSwipeWindow;
+    }
+    
+    public Map<UUID, Long> getActiveCureWindow() {
+        return activeCureWindow;
+    }
+    
+    public Location getCurrentDiscussionLocation() {
+        return currentDiscussionLocation;
+    }
+    
+    public void setCurrentDiscussionLocation(Location location) {
+        this.currentDiscussionLocation = location;
+    }
+    
+    public List<Location> getCurrentSpawnLocations() {
+        return currentSpawnLocations;
+    }
+    
+    public void setCurrentSpawnLocations(List<Location> locations) {
+        this.currentSpawnLocations = locations != null ? new java.util.ArrayList<>(locations) : null;
+    }
+    
+    /**
+     * Cleans up all resources for this session context.
+     */
+    public void cleanup() {
+        activeSwipeWindow.clear();
+        activeCureWindow.clear();
+        currentDiscussionLocation = null;
+        currentSpawnLocations = null;
+        gameState.clearGameState();
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/action/PlayerActionHandler.java
+++ b/src/main/java/com/ohacd/matchbox/game/action/PlayerActionHandler.java
@@ -1,0 +1,205 @@
+package com.ohacd.matchbox.game.action;
+
+import com.ohacd.matchbox.game.SessionGameContext;
+import com.ohacd.matchbox.game.state.GameState;
+import com.ohacd.matchbox.game.utils.GamePhase;
+import com.ohacd.matchbox.game.utils.ParticleUtils;
+import com.ohacd.matchbox.game.utils.Role;
+import com.ohacd.matchbox.game.vote.VoteManager;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Handles player actions during gameplay (swipe, cure, vote).
+ * Separated from GameManager to improve code organization.
+ */
+public class PlayerActionHandler {
+    private final Plugin plugin;
+    
+    public PlayerActionHandler(Plugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    /**
+     * Handles a swipe action from a player.
+     */
+    public void handleSwipe(SessionGameContext context, Player shooter, Player target) {
+        if (context == null || shooter == null || target == null) return;
+        
+        // Both players must be in the same session
+        if (!context.getGameState().getAllParticipatingPlayerIds().contains(target.getUniqueId())) {
+            return;
+        }
+        
+        GameState gameState = context.getGameState();
+        com.ohacd.matchbox.game.phase.PhaseManager phaseManager = context.getPhaseManager();
+        Map<UUID, Long> activeSwipeWindow = context.getActiveSwipeWindow();
+        
+        // Phase and permission checks
+        if (!phaseManager.isPhase(GamePhase.SWIPE)) return;
+        
+        UUID shooterId = shooter.getUniqueId();
+        UUID targetId = target.getUniqueId();
+        
+        // Only a Spark can swipe
+        if (gameState.getRole(shooterId) != Role.SPARK) {
+            return;
+        }
+        
+        // Must have an active swipe window
+        if (!isSwipeWindowActive(context, shooterId)) {
+            return;
+        }
+        
+        // If target already has pending death, ignore duplicate
+        if (gameState.hasPendingDeath(targetId)) {
+            activeSwipeWindow.remove(shooterId);
+            return;
+        }
+        
+        // Mark as swiped and infected
+        gameState.markSwiped(shooterId);
+        gameState.markInfected(targetId);
+        gameState.setPendingDeath(targetId, System.currentTimeMillis());
+        
+        // Show subtle lime particles
+        ParticleUtils.showColoredParticlesToEveryone(
+            target,
+            org.bukkit.Color.fromRGB(50, 205, 50), // Lime green
+            8,
+            plugin
+        );
+        
+        // Close the swipe window
+        activeSwipeWindow.remove(shooterId);
+        
+        plugin.getLogger().info("Swipe registered in session '" + context.getSessionName() + "': " + shooter.getName() + " swiped " + target.getName());
+    }
+    
+    /**
+     * Handles a cure action from a medic.
+     */
+    public void handleCure(SessionGameContext context, Player medic, Player target) {
+        if (context == null || medic == null || target == null) return;
+        
+        // Both players must be in the same session
+        if (!context.getGameState().getAllParticipatingPlayerIds().contains(target.getUniqueId())) {
+            return;
+        }
+        
+        GameState gameState = context.getGameState();
+        com.ohacd.matchbox.game.phase.PhaseManager phaseManager = context.getPhaseManager();
+        Map<UUID, Long> activeCureWindow = context.getActiveCureWindow();
+        
+        // Phase and permission checks
+        if (!phaseManager.isPhase(GamePhase.SWIPE)) return;
+        
+        UUID medicId = medic.getUniqueId();
+        UUID targetId = target.getUniqueId();
+        
+        // Only a Medic can cure
+        if (gameState.getRole(medicId) != Role.MEDIC) {
+            return;
+        }
+        
+        // Must have an active cure window
+        if (!isCureWindowActive(context, medicId)) {
+            return;
+        }
+        
+        // Check if target has a pending death to cure
+        if (!gameState.hasPendingDeath(targetId)) {
+            activeCureWindow.remove(medicId);
+            return;
+        }
+        
+        // Mark as cured
+        gameState.markCured(medicId);
+        gameState.removePendingDeath(targetId);
+        
+        // Show subtle blue particles
+        ParticleUtils.showColoredParticlesToEveryone(
+            target,
+            org.bukkit.Color.fromRGB(0, 100, 255), // Blue
+            8,
+            plugin
+        );
+        
+        // Close the cure window
+        activeCureWindow.remove(medicId);
+        
+        plugin.getLogger().info("Medic " + medic.getName() + " cured " + target.getName() + " in session '" + context.getSessionName() + "'");
+    }
+    
+    /**
+     * Handles a vote action from a player.
+     */
+    public boolean handleVote(SessionGameContext context, Player voter, Player target) {
+        if (context == null || voter == null || target == null) return false;
+        
+        // Both players must be in the same session
+        if (!context.getGameState().getAllParticipatingPlayerIds().contains(target.getUniqueId())) {
+            return false;
+        }
+        
+        GameState gameState = context.getGameState();
+        com.ohacd.matchbox.game.phase.PhaseManager phaseManager = context.getPhaseManager();
+        VoteManager voteManager = context.getVoteManager();
+        
+        // Phase check
+        if (!phaseManager.isPhase(GamePhase.VOTING)) {
+            return false;
+        }
+        
+        UUID voterId = voter.getUniqueId();
+        UUID targetId = target.getUniqueId();
+        
+        // Check if voter and target are alive
+        if (!gameState.isAlive(voterId) || !gameState.isAlive(targetId)) {
+            return false;
+        }
+        
+        // Register the vote
+        boolean success = voteManager.registerVote(voterId, targetId);
+        
+        if (success) {
+            plugin.getLogger().info("Vote registered in session '" + context.getSessionName() + "': " + voter.getName() + " voted for " + target.getName());
+        }
+        
+        return success;
+    }
+    
+    /**
+     * Checks if a player has an active swipe window.
+     */
+    public boolean isSwipeWindowActive(SessionGameContext context, UUID playerId) {
+        if (context == null) return false;
+        Map<UUID, Long> activeSwipeWindow = context.getActiveSwipeWindow();
+        Long expiry = activeSwipeWindow.get(playerId);
+        if (expiry == null) return false;
+        if (expiry <= System.currentTimeMillis()) {
+            activeSwipeWindow.remove(playerId);
+            return false;
+        }
+        return true;
+    }
+    
+    /**
+     * Checks if a player has an active cure window.
+     */
+    public boolean isCureWindowActive(SessionGameContext context, UUID playerId) {
+        if (context == null) return false;
+        Map<UUID, Long> activeCureWindow = context.getActiveCureWindow();
+        Long expiry = activeCureWindow.get(playerId);
+        if (expiry == null) return false;
+        if (expiry <= System.currentTimeMillis()) {
+            activeCureWindow.remove(playerId);
+            return false;
+        }
+        return true;
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/chat/ChatListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/chat/ChatListener.java
@@ -24,9 +24,19 @@ public class ChatListener implements Listener {
         // Check using isAsynchronous() player triggers run asynchronously
         if (!event.isAsynchronous()) return;
         
+        org.bukkit.entity.Player player = event.getPlayer();
+        if (player == null) return;
+        
+        // Find which session the player is in (if any)
+        com.ohacd.matchbox.game.SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
+        if (context == null) {
+            // Player not in any active game - use normal chat
+            return;
+        }
+        
         // Only use holograms during SWIPE phase
         // In DISCUSSION, VOTING, and other phases, use normal chat
-        if (gameManager.phaseManager.getCurrentPhase() != GamePhase.SWIPE) {
+        if (context.getPhaseManager().getCurrentPhase() != GamePhase.SWIPE) {
             // Normal chat - don't cancel, let it work normally
             return;
         }
@@ -36,6 +46,6 @@ public class ChatListener implements Listener {
         // Render the message over the player for 100 ticks or 5 seconds
         String msg = PlainTextComponentSerializer.plainText().serialize(event.message());
         Logger.getLogger(msg);
-        hologramManager.showTextAbove(event.getPlayer(), msg, 100);
+        hologramManager.showTextAbove(player, msg, 100);
     }
 }

--- a/src/main/java/com/ohacd/matchbox/game/lifecycle/GameLifecycleManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/lifecycle/GameLifecycleManager.java
@@ -105,9 +105,6 @@ public class GameLifecycleManager {
                     return (p != null ? p.getName() : id.toString()) + "=" + (role != null ? role : "null");
                 })
                 .collect(java.util.stream.Collectors.joining(", ")));
-        
-        // Start first round
-        startNewRound(context, sessionName);
     }
     
     /**

--- a/src/main/java/com/ohacd/matchbox/game/lifecycle/GameLifecycleManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/lifecycle/GameLifecycleManager.java
@@ -1,0 +1,252 @@
+package com.ohacd.matchbox.game.lifecycle;
+
+import com.ohacd.matchbox.game.SessionGameContext;
+import com.ohacd.matchbox.game.phase.SwipePhaseHandler;
+import com.ohacd.matchbox.game.state.GameState;
+import com.ohacd.matchbox.game.utils.InventoryManager;
+import com.ohacd.matchbox.game.utils.MessageUtils;
+import com.ohacd.matchbox.game.utils.PlayerBackup;
+import com.ohacd.matchbox.game.utils.Role;
+import com.ohacd.matchbox.game.vote.VoteManager;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.*;
+
+import static org.bukkit.Bukkit.getPlayer;
+
+/**
+ * Manages game and round lifecycle (starting games, starting rounds, ending games).
+ * Separated from GameManager to improve code organization.
+ */
+public class GameLifecycleManager {
+    private final Plugin plugin;
+    private final MessageUtils messageUtils;
+    private final SwipePhaseHandler swipePhaseHandler;
+    private final InventoryManager inventoryManager;
+    private final Map<UUID, PlayerBackup> playerBackups;
+    
+    public GameLifecycleManager(Plugin plugin, MessageUtils messageUtils, 
+                                SwipePhaseHandler swipePhaseHandler,
+                                InventoryManager inventoryManager,
+                                Map<UUID, PlayerBackup> playerBackups) {
+        this.plugin = plugin;
+        this.messageUtils = messageUtils;
+        this.swipePhaseHandler = swipePhaseHandler;
+        this.inventoryManager = inventoryManager;
+        this.playerBackups = playerBackups;
+    }
+    
+    /**
+     * Starts a new game for a session.
+     */
+    public void startGame(SessionGameContext context, Collection<Player> players, 
+                         List<Location> spawnLocations, Location discussionLocation, String sessionName) {
+        if (context == null || players == null || players.isEmpty()) {
+            plugin.getLogger().warning("Cannot start game - invalid parameters");
+            return;
+        }
+        
+        if (spawnLocations == null || spawnLocations.isEmpty()) {
+            plugin.getLogger().warning("Cannot start game - no spawn locations");
+            return;
+        }
+        
+        GameState gameState = context.getGameState();
+        
+        // Store round data in context
+        context.setCurrentDiscussionLocation(discussionLocation);
+        context.setCurrentSpawnLocations(spawnLocations);
+        
+        // Clear ALL game state (this is the first round)
+        gameState.clearGameState();
+        context.getPhaseManager().reset();
+        
+        // Store session name
+        gameState.setActiveSessionName(sessionName);
+        
+        // Backup player states before game starts
+        for (Player player : players) {
+            if (player == null || !player.isOnline()) {
+                plugin.getLogger().warning("Skipping null or offline player during backup");
+                continue;
+            }
+            try {
+                playerBackups.put(player.getUniqueId(), new PlayerBackup(player));
+            } catch (Exception e) {
+                plugin.getLogger().severe("Failed to backup player " + (player != null ? player.getName() : "null") + ": " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
+        
+        // Add players to alive set
+        gameState.addAlivePlayers(players);
+        
+        // Assign roles (only once per game, not per round)
+        List<Player> playerList = new ArrayList<>(players);
+        context.getRoleAssigner().assignRoles(playerList);
+        
+        // Validate state after initialization
+        if (!gameState.validateState()) {
+            plugin.getLogger().severe("Game state invalid after initialization: " + gameState.getDebugInfo());
+            plugin.getLogger().severe("Players: " + players.size() + ", Roles assigned: " + gameState.getAllParticipatingPlayerIds().size());
+            // Attempt cleanup
+            gameState.clearGameState();
+            context.getPhaseManager().reset();
+            return;
+        }
+        
+        plugin.getLogger().info("Game started successfully for session '" + sessionName + "' with " + players.size() + " players. Roles: " + 
+            gameState.getAllParticipatingPlayerIds().stream()
+                .map(id -> {
+                    Role role = gameState.getRole(id);
+                    Player p = getPlayer(id);
+                    return (p != null ? p.getName() : id.toString()) + "=" + (role != null ? role : "null");
+                })
+                .collect(java.util.stream.Collectors.joining(", ")));
+        
+        // Start first round
+        startNewRound(context, sessionName);
+    }
+    
+    /**
+     * Starts a new round (after discussion phase ends).
+     */
+    public void startNewRound(SessionGameContext context, String sessionName) {
+        if (context == null) {
+            plugin.getLogger().warning("Cannot start new round - no context for session: " + sessionName);
+            return;
+        }
+        
+        GameState gameState = context.getGameState();
+        VoteManager voteManager = context.getVoteManager();
+        
+        // Check if game is still active (not ended)
+        if (!gameState.isGameActive()) {
+            plugin.getLogger().info("Cannot start new round - game is not active for session: " + sessionName);
+            return;
+        }
+        
+        // Validate state before starting new round
+        if (!gameState.validateState()) {
+            // Broadcast only to players in this session
+            Collection<Player> sessionPlayers = swipePhaseHandler.getAlivePlayerObjects(gameState.getAlivePlayerIds());
+            if (sessionPlayers != null) {
+                for (Player p : sessionPlayers) {
+                    if (p != null && p.isOnline()) {
+                        p.sendMessage("§c§lERROR: Game state is corrupted! Ending game.");
+                    }
+                }
+            }
+            plugin.getLogger().severe("Invalid game state detected for session " + sessionName + ": " + gameState.getDebugInfo());
+            return;
+        }
+        
+        // Increment round counter
+        gameState.incrementRound();
+        int roundNumber = gameState.getCurrentRound();
+        
+        // Broadcast only to players in this session
+        Collection<Player> alivePlayers = swipePhaseHandler.getAlivePlayerObjects(gameState.getAlivePlayerIds());
+        if (alivePlayers != null && !alivePlayers.isEmpty()) {
+            for (Player p : alivePlayers) {
+                if (p != null && p.isOnline()) {
+                    p.sendMessage("§6§l=== ROUND " + roundNumber + " ===");
+                }
+            }
+            messageUtils.sendTitle(
+                    alivePlayers,
+                    "§6§lROUND " + roundNumber,
+                    "§eGet ready to swipe!",
+                    10, // fadeIn (0.5s)
+                    40, // stay (2s)
+                    10  // fadeOut (0.5s)
+            );
+        }
+        
+        // Clear per-round state (swipes, cures, votes) but keep roles and players
+        gameState.clearRoundState();
+        voteManager.clearVotes();
+        inventoryManager.resetArrowUsage();
+        
+        // Clear all inventories for all alive players before new round
+        if (alivePlayers != null) {
+            for (Player player : alivePlayers) {
+                if (player != null && player.isOnline()) {
+                    try {
+                        player.getInventory().clear();
+                        player.updateInventory();
+                    } catch (Exception e) {
+                        plugin.getLogger().warning("Failed to clear inventory for " + player.getName() + " before new round: " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+    
+    /**
+     * Teleports players to spawn locations for a round.
+     */
+    public void teleportPlayersToSpawns(SessionGameContext context, String sessionName) {
+        if (context == null) {
+            return;
+        }
+        
+        GameState gameState = context.getGameState();
+        List<Location> spawnLocations = context.getCurrentSpawnLocations();
+        
+        if (spawnLocations == null || spawnLocations.isEmpty()) {
+            plugin.getLogger().warning("No spawn locations set for round " + gameState.getCurrentRound() + " in session " + sessionName);
+            return;
+        }
+        
+        // Get all alive players
+        List<Player> alivePlayers = new ArrayList<>();
+        for (UUID playerId : gameState.getAlivePlayerIds()) {
+            Player player = getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                alivePlayers.add(player);
+            }
+        }
+        
+        if (alivePlayers.isEmpty()) {
+            return;
+        }
+        
+        // Shuffle spawn locations for randomness
+        List<Location> shuffledSpawns = new ArrayList<>(spawnLocations);
+        Collections.shuffle(shuffledSpawns);
+        Collections.shuffle(alivePlayers);
+        
+        // Distribute players across spawns
+        int spawnCount = shuffledSpawns.size();
+        for (int i = 0; i < alivePlayers.size(); i++) {
+            Player player = alivePlayers.get(i);
+            Location spawnLoc = shuffledSpawns.get(i % spawnCount);
+            
+            Location teleportLoc = spawnLoc.clone();
+            if (teleportLoc == null || teleportLoc.getWorld() == null) {
+                plugin.getLogger().warning("Invalid spawn location for player " + player.getName() + ", skipping teleport");
+                continue;
+            }
+            
+            // Add small random offset if multiple players at same spawn
+            if (alivePlayers.size() > spawnCount) {
+                int playersAtThisSpawn = (i / spawnCount) + 1;
+                if (playersAtThisSpawn > 1) {
+                    double angle = (2 * Math.PI * i) / alivePlayers.size();
+                    double radius = 2.0;
+                    teleportLoc.add(Math.cos(angle) * radius, 0, Math.sin(angle) * radius);
+                }
+            }
+            
+            try {
+                player.teleport(teleportLoc);
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to teleport player " + player.getName() + ": " + e.getMessage());
+            }
+        }
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/phase/DiscussionPhaseHandler.java
+++ b/src/main/java/com/ohacd/matchbox/game/phase/DiscussionPhaseHandler.java
@@ -7,20 +7,23 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
  * Handles the discussion phase logic including timer and countdown.
+ * Supports multiple parallel sessions.
  */
 public class DiscussionPhaseHandler {
     private final Plugin plugin;
     private final MessageUtils messageUtils;
-    private BukkitRunnable discussionTask = null;
+    private final Map<String, BukkitRunnable> discussionTasks = new ConcurrentHashMap<>();
+    private final Map<String, Collection<UUID>> currentPlayerIds = new ConcurrentHashMap<>();
     private final int DEFAULT_DISCUSSION_SECONDS = 30; // 30 seconds discussion
-    private Collection<UUID> currentPlayerIds = null;
 
     public DiscussionPhaseHandler(Plugin plugin, MessageUtils messageUtils) {
         this.plugin = plugin;
@@ -28,9 +31,13 @@ public class DiscussionPhaseHandler {
     }
 
     /**
-     * Starts the discussion phase with a countdown timer.
+     * Starts the discussion phase with a countdown timer for a specific session.
      */
-    public void startDiscussionPhase(int seconds, Collection<UUID> alivePlayerIds, Runnable onPhaseEnd) {
+    public void startDiscussionPhase(String sessionName, int seconds, Collection<UUID> alivePlayerIds, Runnable onPhaseEnd) {
+        if (sessionName == null || sessionName.trim().isEmpty()) {
+            plugin.getLogger().warning("Cannot start discussion phase with null or empty session name");
+            return;
+        }
         if (seconds <= 0) {
             plugin.getLogger().warning("Invalid discussion phase duration: " + seconds);
             return;
@@ -44,9 +51,9 @@ public class DiscussionPhaseHandler {
             return;
         }
         
-        cancelDiscussionTask();
+        cancelDiscussionTask(sessionName);
 
-        this.currentPlayerIds = alivePlayerIds;
+        this.currentPlayerIds.put(sessionName, alivePlayerIds);
 
         plugin.getLogger().info("Starting discussion phase for " + alivePlayerIds.size() + " players (" + seconds + "s)");
         messageUtils.sendPlainMessage("§aDiscussion phase started! You have " + seconds + " seconds to discuss.");
@@ -63,78 +70,117 @@ public class DiscussionPhaseHandler {
         );
 
         AtomicInteger remaining = new AtomicInteger(seconds);
+        final String sessionKey = sessionName;
 
-        discussionTask = new BukkitRunnable() {
+        BukkitRunnable task = new BukkitRunnable() {
             @Override
             public void run() {
                 int secs = remaining.getAndDecrement();
                 if (secs <= 0) {
                     cancel();
-                    discussionTask = null;
-                    plugin.getLogger().info("Discussion phase ended naturally");
-                    clearActionBars(); // Clear action bars before ending
+                    discussionTasks.remove(sessionKey);
+                    currentPlayerIds.remove(sessionKey);
+                    plugin.getLogger().info("Discussion phase ended naturally for session: " + sessionKey);
+                    clearActionBars(sessionKey);
                     onPhaseEnd.run();
                     return;
                 }
-                // Updates actionbar for all alive players
-                Collection<Player> alivePlayers = getAlivePlayerObjects(alivePlayerIds);
-                if (alivePlayers != null) {
-                    for (Player player : alivePlayers) {
-                        if (player != null && player.isOnline()) {
-                            try {
-                                messageUtils.sendActionBar(player, "§eDiscussion: " + secs + "s");
-                            } catch (Exception e) {
-                                // Ignore individual player errors
+                // Updates actionbar for all alive players in this session
+                Collection<UUID> playerIds = currentPlayerIds.get(sessionKey);
+                if (playerIds != null) {
+                    Collection<Player> alivePlayers = getAlivePlayerObjects(playerIds);
+                    if (alivePlayers != null) {
+                        for (Player player : alivePlayers) {
+                            if (player != null && player.isOnline()) {
+                                try {
+                                    messageUtils.sendActionBar(player, "§eDiscussion: " + secs + "s");
+                                } catch (Exception e) {
+                                    // Ignore individual player errors
+                                }
                             }
                         }
                     }
                 }
-                // Broadcast at specific times
+                // Broadcast at specific times (only to players in this session)
                 if (secs == 20 || secs == 10 || secs == 5 || secs <= 3) {
-                    messageUtils.sendPlainMessage("§eDiscussion phase ends in " + secs + " seconds!");
+                    Collection<UUID> playerIdsForMsg = currentPlayerIds.get(sessionKey);
+                    if (playerIdsForMsg != null) {
+                        Collection<Player> players = getAlivePlayerObjects(playerIdsForMsg);
+                        if (players != null && !players.isEmpty()) {
+                            for (Player p : players) {
+                                if (p != null && p.isOnline()) {
+                                    p.sendMessage("§eDiscussion phase ends in " + secs + " seconds!");
+                                }
+                            }
+                        }
+                    }
                 }
             }
         };
-        discussionTask.runTaskTimer(plugin, 0L, 20L);
+        discussionTasks.put(sessionName, task);
+        task.runTaskTimer(plugin, 0L, 20L);
     }
 
     /**
-     * Starts the discussion phase with default duration.
+     * Starts the discussion phase with default duration for a specific session.
      */
-    public void startDiscussionPhase(Collection<UUID> alivePlayerIds, Runnable onPhaseEnd) {
-        startDiscussionPhase(DEFAULT_DISCUSSION_SECONDS, alivePlayerIds, onPhaseEnd);
+    public void startDiscussionPhase(String sessionName, Collection<UUID> alivePlayerIds, Runnable onPhaseEnd) {
+        startDiscussionPhase(sessionName, DEFAULT_DISCUSSION_SECONDS, alivePlayerIds, onPhaseEnd);
     }
 
     /**
-     * Cancels the current discussion phase task.
+     * Cancels the discussion phase task for a specific session.
      */
-    public void cancelDiscussionTask() {
-        if (discussionTask != null) {
+    public void cancelDiscussionTask(String sessionName) {
+        if (sessionName == null) {
+            return;
+        }
+        BukkitRunnable task = discussionTasks.remove(sessionName);
+        if (task != null) {
             try {
-                plugin.getLogger().info("Cancelling discussion phase task");
-                discussionTask.cancel();
-                clearActionBars();
+                plugin.getLogger().info("Cancelling discussion phase task for session: " + sessionName);
+                task.cancel();
+                clearActionBars(sessionName);
             } catch (IllegalStateException ignored) {}
-            discussionTask = null;
+        }
+        currentPlayerIds.remove(sessionName);
+    }
+    
+    /**
+     * Cancels all discussion phase tasks (for cleanup).
+     */
+    public void cancelAllDiscussionTasks() {
+        for (String sessionName : new java.util.HashSet<>(discussionTasks.keySet())) {
+            cancelDiscussionTask(sessionName);
         }
     }
 
     /**
-     * Clears action bars for all tracked players.
+     * Clears action bars for all tracked players in a session.
      */
-    private void clearActionBars() {
-        if (currentPlayerIds != null) {
-            for (Player player : getAlivePlayerObjects(currentPlayerIds)) {
-                messageUtils.sendActionBar(player, "");
+    private void clearActionBars(String sessionName) {
+        Collection<UUID> playerIds = currentPlayerIds.get(sessionName);
+        if (playerIds != null) {
+            Collection<Player> players = getAlivePlayerObjects(playerIds);
+            if (players != null) {
+                for (Player player : players) {
+                    if (player != null && player.isOnline()) {
+                        try {
+                            messageUtils.sendActionBar(player, "");
+                        } catch (Exception e) {
+                            // Ignore individual player errors
+                        }
+                    }
+                }
             }
         }
     }
 
     /**
-     * Checks if discussion phase is currently active.
+     * Checks if discussion phase is currently active for a session.
      */
-    public boolean isActive() {
-        return discussionTask != null;
+    public boolean isActive(String sessionName) {
+        return discussionTasks.containsKey(sessionName);
     }
 
     public Collection<Player> getAlivePlayerObjects(Collection<UUID> playerIds) {

--- a/src/main/java/com/ohacd/matchbox/game/phase/SwipePhaseHandler.java
+++ b/src/main/java/com/ohacd/matchbox/game/phase/SwipePhaseHandler.java
@@ -7,20 +7,23 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 /**
  * Handles the swipe phase logic including timer and countdown.
+ * Supports multiple parallel sessions.
  */
 public class SwipePhaseHandler {
     private final Plugin plugin;
     private final MessageUtils messageUtils;
-    private BukkitRunnable swipeTask = null;
+    private final Map<String, BukkitRunnable> swipeTasks = new ConcurrentHashMap<>();
+    private final Map<String, Collection<UUID>> currentPlayerIds = new ConcurrentHashMap<>();
     private final int DEFAULT_SWIPE_SECONDS = 60 * 3; // 3 minutes
-    private Collection<UUID> currentPlayerIds = null;
 
     public SwipePhaseHandler(Plugin plugin, MessageUtils messageUtils) {
         this.plugin = plugin;
@@ -28,9 +31,13 @@ public class SwipePhaseHandler {
     }
 
     /**
-     * Starts the swipe phase with a countdown timer.
+     * Starts the swipe phase with a countdown timer for a specific session.
      */
-    public void startSwipePhase(int seconds, Collection<UUID> alivePlayerIds, Runnable onPhaseEnd) {
+    public void startSwipePhase(String sessionName, int seconds, Collection<UUID> alivePlayerIds, Runnable onPhaseEnd) {
+        if (sessionName == null || sessionName.trim().isEmpty()) {
+            plugin.getLogger().warning("Cannot start swipe phase with null or empty session name");
+            return;
+        }
         if (seconds <= 0) {
             plugin.getLogger().warning("Invalid swipe phase duration: " + seconds);
             return;
@@ -44,76 +51,106 @@ public class SwipePhaseHandler {
             return;
         }
         
-        cancelSwipeTask();
+        cancelSwipeTask(sessionName);
 
-        this.currentPlayerIds = alivePlayerIds;
+        this.currentPlayerIds.put(sessionName, alivePlayerIds);
 
         plugin.getLogger().info("Starting swipe phase for " + alivePlayerIds.size() + " players (" + seconds + "s)");
         messageUtils.sendPlainMessage("§6Swipe phase started! You have " + seconds + " seconds to swipe.");
 
         AtomicInteger remaining = new AtomicInteger(seconds);
+        final String sessionKey = sessionName;
 
-        swipeTask = new BukkitRunnable() {
+        BukkitRunnable task = new BukkitRunnable() {
             @Override
             public void run() {
                 int secs = remaining.getAndDecrement();
                 if (secs <= 0) {
                     cancel();
-                    swipeTask = null;
-                    plugin.getLogger().info("Swipe phase ended naturally");
-                    clearActionBars(); // Clear action bars before ending
+                    swipeTasks.remove(sessionKey);
+                    currentPlayerIds.remove(sessionKey);
+                    plugin.getLogger().info("Swipe phase ended naturally for session: " + sessionKey);
+                    clearActionBars(sessionKey); // Clear action bars before ending
                     onPhaseEnd.run();
                     return;
                 }
-                // Updates actionbar for all alive players
-                Collection<Player> alivePlayers = getAlivePlayerObjects(alivePlayerIds);
-                if (alivePlayers != null) {
-                    for (Player player : alivePlayers) {
-                        if (player != null && player.isOnline()) {
-                            try {
-                                messageUtils.sendActionBar(player, "§6Swipe: " + secs + "s");
-                            } catch (Exception e) {
-                                // Ignore individual player errors
+                // Updates actionbar for all alive players in this session
+                Collection<UUID> playerIds = currentPlayerIds.get(sessionKey);
+                if (playerIds != null) {
+                    Collection<Player> alivePlayers = getAlivePlayerObjects(playerIds);
+                    if (alivePlayers != null) {
+                        for (Player player : alivePlayers) {
+                            if (player != null && player.isOnline()) {
+                                try {
+                                    messageUtils.sendActionBar(player, "§6Swipe: " + secs + "s");
+                                } catch (Exception e) {
+                                    // Ignore individual player errors
+                                }
                             }
                         }
                     }
                 }
-                // Broadcast at specific times
+                // Broadcast at specific times (only to players in this session)
                 if (secs == 120 || secs == 60 || secs == 30 || secs == 10 || secs == 5 || secs <= 3) {
-                    messageUtils.sendPlainMessage("§eSwipe phase ends in " + secs + " seconds!");
+                    Collection<UUID> playerIdsForMsg = currentPlayerIds.get(sessionKey);
+                    if (playerIdsForMsg != null) {
+                        Collection<Player> players = getAlivePlayerObjects(playerIdsForMsg);
+                        if (players != null && !players.isEmpty()) {
+                            for (Player p : players) {
+                                if (p != null && p.isOnline()) {
+                                    p.sendMessage("§eSwipe phase ends in " + secs + " seconds!");
+                                }
+                            }
+                        }
+                    }
                 }
             }
         };
-        swipeTask.runTaskTimer(plugin, 0L, 20L);
+        swipeTasks.put(sessionName, task);
+        task.runTaskTimer(plugin, 0L, 20L);
     }
 
     /**
-     * Starts the swipe phase with default duration.
+     * Starts the swipe phase with default duration for a specific session.
      */
-    public void startSwipePhase(Collection<UUID> alivePlayerIds, Runnable onPhaseEnd) {
-        startSwipePhase(DEFAULT_SWIPE_SECONDS, alivePlayerIds, onPhaseEnd);
+    public void startSwipePhase(String sessionName, Collection<UUID> alivePlayerIds, Runnable onPhaseEnd) {
+        startSwipePhase(sessionName, DEFAULT_SWIPE_SECONDS, alivePlayerIds, onPhaseEnd);
     }
 
     /**
-     * Cancels the current swipe phase task.
+     * Cancels the swipe phase task for a specific session.
      */
-    public void cancelSwipeTask() {
-        if (swipeTask != null) {
+    public void cancelSwipeTask(String sessionName) {
+        if (sessionName == null) {
+            return;
+        }
+        BukkitRunnable task = swipeTasks.remove(sessionName);
+        if (task != null) {
             try {
-                plugin.getLogger().info("Cancelling swipe phase task");
-                swipeTask.cancel();
-                clearActionBars();
+                plugin.getLogger().info("Cancelling swipe phase task for session: " + sessionName);
+                task.cancel();
+                clearActionBars(sessionName);
             } catch (IllegalStateException ignored) {}
-            swipeTask = null;
+        }
+        currentPlayerIds.remove(sessionName);
+    }
+    
+    /**
+     * Cancels all swipe phase tasks (for cleanup).
+     */
+    public void cancelAllSwipeTasks() {
+        for (String sessionName : new java.util.HashSet<>(swipeTasks.keySet())) {
+            cancelSwipeTask(sessionName);
         }
     }
 
     /**
-     * Clears action bars for all tracked players.
+     * Clears action bars for all tracked players in a session.
      */
-    private void clearActionBars() {
-        if (currentPlayerIds != null) {
-            Collection<Player> players = getAlivePlayerObjects(currentPlayerIds);
+    private void clearActionBars(String sessionName) {
+        Collection<UUID> playerIds = currentPlayerIds.get(sessionName);
+        if (playerIds != null) {
+            Collection<Player> players = getAlivePlayerObjects(playerIds);
             if (players != null) {
                 for (Player player : players) {
                     if (player != null && player.isOnline()) {
@@ -129,10 +166,10 @@ public class SwipePhaseHandler {
     }
 
     /**
-     * Checks if swipe phase is currently active.
+     * Checks if swipe phase is currently active for a session.
      */
-    public boolean isActive() {
-        return swipeTask != null;
+    public boolean isActive(String sessionName) {
+        return swipeTasks.containsKey(sessionName);
     }
 
     public Collection<Player> getAlivePlayerObjects(Collection<UUID> playerIds) {

--- a/src/main/java/com/ohacd/matchbox/game/role/RoleAssigner.java
+++ b/src/main/java/com/ohacd/matchbox/game/role/RoleAssigner.java
@@ -56,9 +56,5 @@ public class RoleAssigner {
         for (int i = 2; i < shuffled.size(); i++) {
             gameState.setRole(shuffled.get(i).getUniqueId(), Role.INNOCENT);
         }
-        
-        // Safety check: if only 1 player, they become Spark (no Medic)
-        // If only 2 players, first is Spark, second is Medic (no Innocents)
-        // This is already handled by the logic above
     }
 }

--- a/src/main/java/com/ohacd/matchbox/game/state/GameState.java
+++ b/src/main/java/com/ohacd/matchbox/game/state/GameState.java
@@ -15,20 +15,10 @@ public class GameState {
     private final Set<UUID> curedThisRound = new HashSet<>();
     private final Set<UUID> usedHealingSightThisRound = new HashSet<>();
     private final Set<UUID> usedHunterVisionThisRound = new HashSet<>();
-
-    // NEW: track infected (swiped successfully) this round (before pending death application)
     private final Set<UUID> infectedThisRound = new HashSet<>();
-
-    // NEW: pending death times (epoch millis when the pending elimination should be applied)
     private final Map<UUID, Long> pendingDeathTime = new HashMap<>();
-
-    // Track ALL players who started the round (for nametag restoration)
     private final Set<UUID> allParticipatingPlayers = new HashSet<>();
-
-    // Track which session is currently active
     private String activeSessionName = null;
-
-    // Track current round number
     private int currentRound = 0;
 
     /**
@@ -60,7 +50,6 @@ public class GameState {
         infectedThisRound.clear();
         usedHealingSightThisRound.clear();
         usedHunterVisionThisRound.clear();
-        // Note: do NOT clear pendingDeathTime here — pending deaths may span rounds.
     }
 
     /**
@@ -107,7 +96,7 @@ public class GameState {
 
     /**
      * Removes a player from the alive players set.
-     * Note: This does NOT remove them from allParticipatingPlayers.
+     * Does not remove them from allParticipatingPlayers.
      */
     public void removeAlivePlayer(UUID playerId) {
         if (playerId == null) {

--- a/src/main/java/com/ohacd/matchbox/game/utils/GameItemProtectionListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/GameItemProtectionListener.java
@@ -5,12 +5,15 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.ItemStack;
 
 /**
  * Prevents players from moving or dropping game items.
+ * Game items are completely locked in place - no moving, dropping, hotkeying, or shift-clicking.
  */
 public class GameItemProtectionListener implements Listener {
     
@@ -23,21 +26,50 @@ public class GameItemProtectionListener implements Listener {
         // Check if clicking a game item
         ItemStack clicked = event.getCurrentItem();
         if (clicked != null && InventoryManager.isGameItem(clicked)) {
-            // Allow right-click for activation, but prevent moving
-            if (event.getClick().isShiftClick() || event.getClick().isLeftClick()) {
+            // For voting papers, allow right-click ONLY during voting phase
+            if (InventoryManager.isVotingPaper(clicked)) {
+                // Right-click is handled by VotePaperListener - prevent all other interactions
+                if (!event.getClick().isRightClick()) {
+                    event.setCancelled(true);
+                    return;
+                }
+                // Right-click will be handled by VotePaperListener
+                return;
+            }
+            
+            // For all other game items (role paper, ability papers, crossbow, arrow):
+            // Prevent ALL interactions except right-click for ability activation
+            // This includes: left-click, shift-click, number key (hotkey), middle-click, etc.
+            if (!event.getClick().isRightClick() || event.getClick().isShiftClick() || 
+                event.getClick().isKeyboardClick() || event.getClick().isCreativeAction()) {
                 event.setCancelled(true);
                 return;
             }
-            // Right-click is allowed for ability activation
+            // Right-click is allowed for ability activation (handled by ability listeners)
         }
         
-        // Check if trying to move a game item
+        // Check if trying to move a game item with cursor
         ItemStack cursor = event.getCursor();
         if (cursor != null && InventoryManager.isGameItem(cursor)) {
-            // Prevent moving game items
-            if (event.getClick().isShiftClick() || event.getClick().isLeftClick()) {
+            // Prevent ALL movement of game items (including right-click moving)
+            event.setCancelled(true);
+            return;
+        }
+        
+        // Prevent hotkey swapping (number keys) with game items
+        if (event.getClick().isKeyboardClick() || event.getClick().isShiftClick()) {
+            // Check if the item being moved is a game item
+            if (clicked != null && InventoryManager.isGameItem(clicked)) {
                 event.setCancelled(true);
                 return;
+            }
+            // Check if trying to swap with a game item in hotbar
+            if (event.getHotbarButton() >= 0) {
+                ItemStack hotbarItem = event.getWhoClicked().getInventory().getItem(event.getHotbarButton());
+                if (hotbarItem != null && InventoryManager.isGameItem(hotbarItem)) {
+                    event.setCancelled(true);
+                    return;
+                }
             }
         }
         
@@ -45,29 +77,49 @@ public class GameItemProtectionListener implements Listener {
         int slot = event.getSlot();
         if (slot == InventoryManager.getRolePaperSlot() ||
             slot == InventoryManager.getSwipeCurePaperSlot() ||
-            slot == InventoryManager.getVisionSightPaperSlot()) {
-            // Only allow right-click on these slots (for ability activation)
-            if (event.getClick().isShiftClick() || event.getClick().isLeftClick()) {
+            slot == InventoryManager.getVisionSightPaperSlot() ||
+            slot == InventoryManager.getCrossbowHotbarSlot() ||
+            slot == InventoryManager.getArrowHotbarSlot()) {
+            // If there's a cursor item (trying to place something), always prevent
+            if (cursor != null && !InventoryManager.isGameItem(cursor)) {
+                event.setCancelled(true);
+                return;
+            }
+            // If clicking on an empty slot with a game item in cursor, prevent
+            if (clicked == null && cursor != null && InventoryManager.isGameItem(cursor)) {
+                event.setCancelled(true);
+                return;
+            }
+            // For right-click activation, only allow if no cursor item and clicking existing game item
+            if (event.getClick().isRightClick() && cursor == null && clicked != null && InventoryManager.isGameItem(clicked)) {
+                // Allow - will be handled by ability listeners
+                return;
+            }
+            // Prevent all other interactions
+            if (!event.getClick().isRightClick() || cursor != null) {
                 event.setCancelled(true);
             }
         }
         
         // Prevent moving items into voting paper slots (0-6) during voting phase
-        // But allow right-click for voting
         if (slot >= 0 && slot <= 6) {
             ItemStack item = event.getCurrentItem();
             if (item != null && InventoryManager.isVotingPaper(item)) {
-                // Allow right-click for voting, prevent moving
-                if (event.getClick().isShiftClick() || event.getClick().isLeftClick()) {
+                // Allow right-click for voting, prevent all other interactions
+                if (!event.getClick().isRightClick()) {
                     event.setCancelled(true);
                 }
             }
+            // Prevent placing items in voting slots
+            if (cursor != null && !InventoryManager.isVotingPaper(cursor)) {
+                event.setCancelled(true);
+            }
         }
         
-        // Prevent moving items into hotbar slots 7 and 8
+        // Prevent moving items into hotbar slots 7 and 8 (crossbow and arrow)
         if (event.getInventory().getType() == InventoryType.PLAYER) {
             int rawSlot = event.getRawSlot();
-            // Hotbar slots 7 and 8 in player inventory
+            // Hotbar slots 7 and 8 in player inventory (raw slots 43 and 44)
             if (rawSlot == 43 || rawSlot == 44) {
                 ItemStack item = event.getCursor();
                 if (item != null && !InventoryManager.isGameItem(item)) {
@@ -79,9 +131,49 @@ public class GameItemProtectionListener implements Listener {
     }
     
     @EventHandler(priority = EventPriority.HIGHEST)
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+        
+        // Prevent dragging game items
+        ItemStack dragged = event.getOldCursor();
+        if (dragged != null && InventoryManager.isGameItem(dragged)) {
+            event.setCancelled(true);
+            return;
+        }
+        
+        // Prevent dragging items into game item slots
+        for (int slot : event.getRawSlots()) {
+            if (slot == InventoryManager.getRolePaperSlot() ||
+                slot == InventoryManager.getSwipeCurePaperSlot() ||
+                slot == InventoryManager.getVisionSightPaperSlot() ||
+                slot == InventoryManager.getCrossbowHotbarSlot() ||
+                slot == InventoryManager.getArrowHotbarSlot() ||
+                (slot >= 0 && slot <= 6)) { // Voting paper slots
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+    
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerDropItem(PlayerDropItemEvent event) {
         ItemStack item = event.getItemDrop().getItemStack();
         if (InventoryManager.isGameItem(item)) {
+            event.setCancelled(true);
+            event.getPlayer().updateInventory();
+        }
+    }
+    
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerSwapHandItems(PlayerSwapHandItemsEvent event) {
+        // Prevent swapping if either hand has a game item
+        ItemStack mainHand = event.getMainHandItem();
+        ItemStack offHand = event.getOffHandItem();
+        
+        if ((mainHand != null && InventoryManager.isGameItem(mainHand)) ||
+            (offHand != null && InventoryManager.isGameItem(offHand))) {
             event.setCancelled(true);
             event.getPlayer().updateInventory();
         }

--- a/src/main/java/com/ohacd/matchbox/game/utils/GamePhase.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/GamePhase.java
@@ -1,10 +1,19 @@
 package com.ohacd.matchbox.game.utils;
 
+/**
+ * Represents the different phases of a game round.
+ */
 public enum GamePhase {
-    WAITING, // The phase where players are waiting for the game
-    SWIPE, // The phase where the players are actively in the game, swiping, healing and things of sort happen here
+    /** Players are waiting for the game to start */
+    WAITING,
+    /** Active gameplay phase where players can swipe, cure, and use abilities */
+    SWIPE,
+    /** Discussion phase where players can talk and strategize */
     DISCUSSION,
+    /** Voting phase where players vote to eliminate suspects */
     VOTING,
+    /** Resolution phase (currently unused) */
     RESOLUTION,
+    /** Game has ended */
     ENDED
 }

--- a/src/main/java/com/ohacd/matchbox/game/utils/HitRevealListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/HitRevealListener.java
@@ -61,8 +61,5 @@ public class HitRevealListener implements Listener {
         // Remove arrow from inventory (they used it)
         shooter.getInventory().setItem(InventoryManager.getArrowHotbarSlot(), null);
         shooter.updateInventory();
-        
-        // Note: Swipe is now completely delinked from arrows
-        // Swipe can only be activated via the paper in slot 27
     }
 }

--- a/src/main/java/com/ohacd/matchbox/game/utils/InventoryManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/InventoryManager.java
@@ -22,7 +22,7 @@ public class InventoryManager {
     private final Plugin plugin;
     
     // Slot constants
-    private static final int ROLE_PAPER_SLOT = 8; // Top rightmost slot in inventory
+    private static final int ROLE_PAPER_SLOT = 17; // Top rightmost slot in inventory (top row, rightmost)
     private static final int SWIPE_CURE_PAPER_SLOT = 27; // Above hotbar slot 0
     private static final int VISION_SIGHT_PAPER_SLOT = 28; // Above hotbar slot 1
     private static final int CROSSBOW_HOTBAR_SLOT = 7; // Hotbar slot 7 (second from right)

--- a/src/main/java/com/ohacd/matchbox/game/utils/Role.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/Role.java
@@ -1,7 +1,13 @@
 package com.ohacd.matchbox.game.utils;
 
+/**
+ * Represents the different roles players can have in the game.
+ */
 public enum Role {
+    /** The impostor who tries to eliminate all other players */
     SPARK,
+    /** Can cure infected players and see who is infected */
     MEDIC,
+    /** Regular player who must identify and vote out the Spark */
     INNOCENT
 }

--- a/src/main/java/com/ohacd/matchbox/game/utils/VoteItemListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/VoteItemListener.java
@@ -1,14 +1,16 @@
 package com.ohacd.matchbox.game.utils;
 
 import com.ohacd.matchbox.game.GameManager;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Handles voting by right-clicking on players during the voting phase.
- * Similar to SwipeHitListener but for voting.
+ * Works when player is holding a voting paper in their main hand.
  */
 public class VoteItemListener implements Listener {
     private final GameManager gameManager;
@@ -29,12 +31,39 @@ public class VoteItemListener implements Listener {
             return;
         }
 
-        // Delegate to GameManager; it will enforce voting rules
+        // Check if voter is holding a voting paper in their main hand
+        ItemStack heldItem = voter.getInventory().getItemInMainHand();
+        if (heldItem == null || heldItem.getType() != Material.PAPER || !InventoryManager.isVotingPaper(heldItem)) {
+            return;
+        }
+
+        // Get target player name from paper
+        String targetName = InventoryManager.getVotingPaperTarget(heldItem);
+        if (targetName == null || !targetName.equals(target.getName())) {
+            // Paper doesn't match the clicked player - ignore
+            return;
+        }
+
+        // Check if voter is alive
+        if (!gameManager.getGameState().isAlive(voter.getUniqueId())) {
+            return;
+        }
+
+        // Check if target is alive
+        if (!gameManager.getGameState().isAlive(target.getUniqueId())) {
+            return;
+        }
+
+        // Register the vote
         boolean success = gameManager.handleVote(voter, target);
         
         if (success) {
             // Prevent any other interaction side-effects
             event.setCancelled(true);
+            
+            // Remove the voting paper from main hand after successful vote
+            voter.getInventory().setItemInMainHand(null);
+            voter.updateInventory();
         }
     }
 }

--- a/src/main/java/com/ohacd/matchbox/game/utils/VotePaperListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/VotePaperListener.java
@@ -30,8 +30,10 @@ public class VotePaperListener implements Listener {
             return;
         }
         
-        // Only allow right-click for voting
-        if (!event.getClick().isRightClick()) {
+        // Allow both left-click and right-click for voting in inventory
+        boolean isRightClick = event.getClick().isRightClick();
+        boolean isLeftClick = event.getClick().isLeftClick();
+        if (!isRightClick && !isLeftClick) {
             return;
         }
         

--- a/src/main/java/com/ohacd/matchbox/game/vote/VoteManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/vote/VoteManager.java
@@ -55,12 +55,7 @@ public class VoteManager {
         }
         
         // Register the vote
-        UUID previousTarget = votes.put(voterId, targetId);
-        
-        // Update vote counts
-        if (previousTarget != null) {
-            voteCounts.put(previousTarget, voteCounts.getOrDefault(previousTarget, 1) - 1);
-        }
+        votes.put(voterId, targetId);
         voteCounts.put(targetId, voteCounts.getOrDefault(targetId, 0) + 1);
         
         return true;

--- a/src/main/java/com/ohacd/matchbox/game/win/WinConditionChecker.java
+++ b/src/main/java/com/ohacd/matchbox/game/win/WinConditionChecker.java
@@ -1,6 +1,8 @@
 package com.ohacd.matchbox.game.win;
 
 import com.ohacd.matchbox.game.state.GameState;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 
 /**
  * Checks win conditions for the game.
@@ -10,6 +12,21 @@ public class WinConditionChecker {
 
     public WinConditionChecker(GameState gameState) {
         this.gameState = gameState;
+    }
+
+    /**
+     * Gets the spark's player name from UUID.
+     */
+    private String getSparkName(java.util.UUID sparkUUID) {
+        if (sparkUUID == null) {
+            return "Unknown";
+        }
+        Player sparkPlayer = Bukkit.getPlayer(sparkUUID);
+        if (sparkPlayer != null && sparkPlayer.isOnline()) {
+            return sparkPlayer.getName();
+        }
+        // Fallback: try to get name from offline player or return UUID string
+        return sparkUUID.toString();
     }
 
     /**
@@ -23,23 +40,24 @@ public class WinConditionChecker {
             return null; // No spark assigned, game not ready
         }
 
+        String sparkName = getSparkName(sparkUUID);
         boolean sparkAlive = gameState.isAlive(sparkUUID);
         long aliveInnocents = gameState.countAliveInnocents();
         int aliveCount = gameState.getAlivePlayerCount();
 
         // Condition 1: Spark is dead → Innocents win
         if (!sparkAlive) {
-            return new WinResult(Winner.INNOCENTS, "§aInnocents win! The Spark has been eliminated.");
+            return new WinResult(Winner.INNOCENTS, "§aInnocents win! The Spark (" + sparkName + ") has been eliminated.");
         }
 
         // Condition 2: No innocents alive → Spark wins
         if (aliveInnocents == 0) {
-            return new WinResult(Winner.SPARK, "§cSpark wins! All innocents have been eliminated.");
+            return new WinResult(Winner.SPARK, "§c" + sparkName + " (Spark) wins! All innocents have been eliminated.");
         }
 
         // Condition 3: Spark is alone with 1 other player → Spark wins
         if (aliveCount == 2) {
-            return new WinResult(Winner.SPARK, "§cSpark wins! Only one other player remains.");
+            return new WinResult(Winner.SPARK, "§c" + sparkName + " (Spark) wins! Only one other player remains.");
         }
 
         return null; // No win condition met

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Matchbox
-version: '0.8-beta'
+version: '0.8.5-beta'
 main: com.ohacd.matchbox.Matchbox
 api-version: '1.21'
 authors: [ OhACD ]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Matchbox
-version: '0.8.5-beta'
+version: '0.8.6-beta'
 main: com.ohacd.matchbox.Matchbox
 api-version: '1.21'
 authors: [ OhACD ]


### PR DESCRIPTION
This PR skips version 0.8.5 to deliver the first production ready version for the plugin - check changelog to see version 0.8.5 changelog.

## [0.8.6-beta] - Latest

### Code Quality & Documentation
- **Code Cleanup**: Comprehensive codebase cleanup and refactoring
  - Removed non-essential comments ("NEW:", "Note:", "Edge case:", etc.)
  - Removed obsolete TODO comments
  - Cleaned up verbose inline comments that didn't add value
  - Removed redundant code and dead branches
- **Documentation Improvements**: Enhanced code documentation
  - Added comprehensive JavaDoc to main plugin class (Matchbox)
  - Added detailed JavaDoc to enums (GamePhase, Role)
  - Improved class-level documentation (SessionGameContext, etc.)
  - Added proper @Deprecated annotations with migration guidance
  - Enhanced field documentation with clear descriptions
- **Bug Fixes**: Fixed logic issues and potential bugs
  - Fixed redundant vote count update logic in VoteManager (removed unreachable code)
  - Removed dead code branches that could never execute
  - Improved code clarity and maintainability

### Fixed
- **Double Round Messages**: Fixed issue where players received two round messages (round 1 and round 2) when starting a game
  - Removed duplicate `startNewRound()` call in `GameManager.startRound()`
  - Round counter now correctly starts at 1 instead of jumping to 2
- **Session Cleanup**: Fixed issue where sessions remained in the list after game ended
  - Sessions are now fully removed from SessionManager when game ends (complete termination)
  - Updated `list` command to filter out inactive sessions
  - No need to use `stop` command for full session termination
- **Spark Name Announcement**: Fixed win message to include the Spark's player name
  - Win messages now show: `"[PlayerName] (Spark) wins!"` instead of just "Spark wins!"
  - Applies to all Spark win conditions
- **Voting Paper Activation**: Enhanced voting paper interaction support
  - Added left-click support in inventory (previously only right-click)
  - Right-click in inventory still works
  - Right-click when held in main hand still works (via VoteItemListener)
  - Players can now vote using any of these methods

### Changed
- **Session Termination**: Sessions are now fully removed when game ends, not just marked inactive
  - Ensures complete cleanup and prevents memory leaks
  - Sessions automatically removed from SessionManager on game end

---