### PR TITLE
1.0.0: Check change log

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,197 +2,122 @@
 
 All notable changes to the Matchbox plugin will be documented in this file.
 
-
-## [0.9.0] - Latest
+## [1.0.0] - Latest Release
 
 ### Added
-- **Global Swipe/Cure Indicators**: The subtle particle cues for Spark swipes and Medic cures now broadcast to every nearby player, keeping spectators and recordings informed without exposing roles.
-- **Player-Focused Cure Notice**: Cured players receive a direct chat message so the announcement no longer conflicts with the discussion-phase titles.
-- **Hunter Vision Resilience**: ProtocolLib Hunter Vision now uses the modern `DataValue` pipeline, automatically falling back to the particle adapter whenever packet delivery fails.
-
-### Fixed
-- **Spark Disconnects**: Resolved `clientbound/minecraft:set_entity_data` crashes that kicked Sparks whenever glow packets used the legacy `DataItem`.
-- **Random Skin Preload**: The curated skin pool now resolves Mojang UUIDs before requesting textures, eliminating the “Failed to fetch skin” spam and guaranteeing usable skins even on offline-mode servers.
+- **Config File Support**: Full configuration system with `config.yml`
+  - Configurable phase durations (swipe, discussion, voting)
+  - Configurable player limits (min/max players per session)
+  - Configurable seat spawn numbers for discussion phase
+  - Random skins toggle (enable/disable)
+- **Seat Location System**: Discussion phase seat spawns
+  - Set seat locations via `/matchbox setseat <session> <number>` command
+  - List seat locations via `/matchbox listseatspawns` command
+  - Remove set seat locations via `/matchbox removeseat <index>` command
+  - Configure seat coordinates in config file
+  - Players automatically teleported to seats during discussion
+- **Spawn Location Configuration**: Game spawn locations in config
+  - Set spawn locations via `/matchbox setspawn <session>` command
+  - List spawn locations via `/matchbox listspawns`
+  - Remove set spawn locations via `/matchbox removespawn <index>`
+  - Configure spawn coordinates in config file
+  - Automatic loading from config when sessions don't have locations
+- **Skin Restoration System**: Enhanced skin management
+  - Player skins return to normal during discussion phase
+  - Assigned skins restored after discussion ends
+- **Damage Protection**: Players are invulnerable during active games
+  - All damage sources blocked (hits, lava, fall damage, etc.)
+  - Death prevention during games
+  - Hunger loss prevention
+- **Block Interaction Protection**: Block interactions disabled during games
+  - Right-click and left-click on blocks blocked
+  - Item interactions still work (abilities, voting)
+- **Config Validation**: Added bound checks to all config values
+  - Phase durations: Swipe (30-600s), Discussion (5-300s), Voting (5-120s)
+  - Player limits: Min (2-7), Max (2-20) with cross-validation
+  - Min spawn locations: (1-50)
+  
 
 ### Changed
-- **Terminology Refresh**: All references to “red particles” now describe neutral highlight markers to match the actual visuals.
-- **Import Hygiene**: Replaced inline `java.util.*` usages with conventional imports to keep compilation warnings noise-free.
-- **Version Jump**: Skipped the remaining 0.8.x line to mark these stability upgrades as the start of the 0.9 series. Config support remains the final blocker for 1.0.
+- **Location Management**: Locations can be set via commands or config file
+  - Commands automatically save to config
+  - Config locations used as defaults for new sessions
+- **Phase Durations**: All phase durations configurable via config file
+  - Default: Swipe (180s), Discussion (30s), Voting (15s)
+- **Player Limits**: Min/max players configurable via config file
+  - Default: Min 2, Max 7 players
+
+### Fixed
+- Session system cleanup and state management
+- Deprecated method usage in leave command
+- Discussion/seat location teleportation logic
+- Player state restoration on game end
+- All commands have been added to tab with proper permission checks
+
+---
+
+## [0.9.0]
+
+### Added
+- Global swipe/cure indicators broadcast to all nearby players
+- Player-focused cure notifications
+- Hunter Vision resilience with modern ProtocolLib pipeline
+
+### Fixed
+- Spark disconnects from legacy glow packets
+- Random skin preload with proper UUID resolution
+
+### Changed
+- Terminology updates
+- Import hygiene improvements
 
 ---
 
 ## [0.8.7-beta]
 
 ### Added
-- **ProtocolLib Hunter Vision**: Sparks now get a live 35-block glow of players through walls. Automatically falls back to particle indicators (with a startup log) when ProtocolLib is missing.
-- **Temporary Random Skins**: Players in an active game receive a curated random skin for the entire match and are restored afterwards.
-- **Cured Player Feedback**: Players cured by the Medic are notified via title + log at the start of discussion.
+- ProtocolLib Hunter Vision support
+- Temporary random skins during matches
+- Cured player feedback
 
 ### Fixed
-- **Ability Paper Loss**: Swipe/Cure papers are restored when the activation window expires unused.
-- **Phase Visibility**: Nametags are now visible during discussion/voting phases while remaining hidden during swipe.
-- **Plugin Disable Runnable**: All scheduled tasks are cancelled during plugin shutdown to prevent asynchronous errors.
-- **Import Hygiene**: Replaced fully qualified references with imports and tightened null/phase guards across listeners.
-
-### Changed
-- **Hunter Vision API**: Introduced `HunterVisionAdapter` abstraction, enabling clean separation between ProtocolLib and fallback implementations.
+- Ability paper restoration
+- Phase visibility for nametags
+- Plugin disable cleanup
 
 ---
 
 ## [0.8.6-beta]
 
 ### Fixed
-- **Double Round Messages**: Fixed issue where players received two round messages (round 1 and round 2) when starting a game
-  - Removed duplicate `startNewRound()` call in `GameManager.startRound()`
-  - Round counter now correctly starts at 1 instead of jumping to 2
-- **Session Cleanup & Termination**: Fixed multiple session management issues
-  - Sessions are now fully removed from SessionManager when game ends (complete termination)
-  - Sessions properly terminated on game end - marked inactive and removed from SessionManager
-  - Fixed memory leak where valid waiting sessions were being deleted by list command
-  - Sessions are now only removed if they have 0 players (truly empty)
-  - Inactive sessions with players are now correctly shown as "[Waiting]" in list command
-- **Session List Command**: Fixed critical bug where valid sessions were being removed from the list
-  - Sessions created with `/matchbox start` now properly appear in the list
-  - Sessions persist until they're terminated or become empty
-  - Fixed session name display - now shows case-preserved names correctly
-  - `getAllSessionNames()` now returns case-preserved session names instead of lowercase keys
-- **Inventory Protection**: Fixed issue where inventory protection was active for all players, even when not in a game
-  - Inventory protection now only activates when player is in an active game session
-  - Players can now freely move items when not in a game
-  - Added `isPlayerInActiveGame()` check to all protection event handlers
-  - `GameItemProtectionListener` now requires `GameManager` to check player game state
-- **Spark Name Announcement**: Fixed win message to include the Spark's player name
-  - Win messages now show: `"[PlayerName] (Spark) wins!"` instead of just "Spark wins!"
-  - Applies to all Spark win conditions
-  - Spark name is retrieved from UUID and displayed in all win scenarios
-- **Voting Paper Activation**: Enhanced voting paper interaction support
-  - Added left-click support in inventory (previously only right-click)
-  - Right-click in inventory still works
-  - Right-click when held in main hand still works (via VoteItemListener)
-  - Players can now vote using any of these methods
-- **VoteManager Logic**: Fixed redundant vote count update logic
-  - Removed unreachable code that checked for previous vote targets
-  - Simplified vote registration logic for better performance
-- **NullPointerException in Listeners**: Fixed critical bug where listeners crashed when no active sessions exist
-  - `VotePaperListener` now uses session-specific context instead of deprecated `getPhaseManager()`
-  - `VoteItemListener` now uses session-specific context instead of deprecated methods
-  - `HitRevealListener` now uses session-specific context instead of deprecated methods
-  - All listeners now properly check if player is in an active game before processing events
-  - Prevents crashes when players interact with items outside of active games
-- **Voting & Ability Activation**: Enhanced activation methods for all papers
-  - Voting papers can now be activated via: right-click in inventory, left-click in inventory, or right-click when held in main hand
-  - Ability papers (Swipe, Cure, Hunter Vision, Healing Sight) can now be activated via: right-click in inventory, left-click in inventory, or right-click when held in main hand
-  - Fixed right-click on main hand for voting papers - now properly works when holding paper
-  - All activation methods now work consistently across all papers
-- **Visual Ability Indicators**: Added visual feedback for used abilities and votes
-  - Used papers are now replaced with gray dye items showing "[USED]" status
-  - Gray dye maintains the same display name and lore as the original paper
-  - Provides clear visual indication that an ability/vote has been used this round
-  - Integrated seamlessly into existing logic without breaking functionality
-- **Game State Safety Checks**: Enhanced all event listeners with comprehensive game state validation
-  - All action handlers now verify game is active before processing any game logic
-  - All ability listeners check `isGameActive()` before allowing ability activation
-  - All voting listeners check `isGameActive()` before processing votes
-  - All hit listeners check `isGameActive()` before processing player interactions
-  - Prevents game logic from executing when players are not in active games
-  - Prevents phase-specific logic from executing in wrong phases
-  - Ensures robust separation between active games and inactive players
-
-### Changed
-- **Session Termination**: Sessions are now fully removed when game ends, not just marked inactive
-  - Ensures complete cleanup and prevents memory leaks
-  - Sessions automatically removed from SessionManager on game end
-  - No need to use `stop` command for full session termination
-- **Voting Phase Instructions**: Added helpful voting instructions during voting phase
-  - Players now receive clear instructions on how to vote when voting phase begins
-  - Instructions explain: right-click paper in inventory, left-click paper in inventory, or right-click player while holding their paper
-  - Helps players understand voting mechanics, especially useful with custom skins where names might not be visible
-
-### Code Quality & Documentation
-- **Code Cleanup**: Comprehensive codebase cleanup and refactoring
-  - Removed non-essential comments ("NEW:", "Note:", "Edge case:", etc.)
-  - Removed obsolete TODO comments
-  - Cleaned up verbose inline comments that didn't add value
-  - Removed redundant code and dead branches
-- **Documentation Improvements**: Enhanced code documentation
-  - Added comprehensive JavaDoc to main plugin class (Matchbox)
-  - Added detailed JavaDoc to enums (GamePhase, Role)
-  - Improved class-level documentation (SessionGameContext, etc.)
-  - Added proper @Deprecated annotations with migration guidance
-  - Enhanced field documentation with clear descriptions
-- **Code Quality**: Improved code clarity and maintainability
-  - Removed dead code branches that could never execute
-  - Better organized event listener registration
-  - Improved error handling and logging
+- Double round messages
+- Session cleanup and termination
+- Inventory protection scope
+- Voting paper activation methods
+- NullPointerException in listeners
 
 ---
 
-## [0.8.5-beta]  
+## [0.8.5-beta]
 
 ### Added
-- **Parallel Game Sessions**: Multiple games can now run simultaneously without interfering with each other
-- **Session Context Management**: Introduced `SessionGameContext` to encapsulate all game state per session
-- **Edge Case Handling**: Added comprehensive edge case handling for parallel sessions
-  - Players cannot join multiple sessions simultaneously
-  - Automatic cleanup of orphaned contexts
-  - Session validation before context creation
-  - Emergency cleanup on plugin disable
-- **Memory Leak Prevention**: Enhanced session termination and cleanup
-  - Sessions automatically end when all players leave
-  - Sessions automatically end when game ends and winner is announced
-  - Proper cleanup of timers, tasks, and player backups
-  - Emergency cleanup method for plugin shutdown
-- **Code Refactoring**: Refactored `GameManager` into smaller, focused classes
-  - `GameLifecycleManager`: Handles game and round lifecycle (fully integrated)
-  - `PlayerActionHandler`: Handles player actions (swipe, cure, vote) (fully integrated)
+- Parallel game sessions support
+- Session context management
+- Memory leak prevention
 
 ### Fixed
-- **Timer Reset Bug**: Fixed issue where timers didn't reset when phases were force-skipped
-  - Swipe timer now properly cancels when discussion phase starts
-  - Discussion timer now properly cancels when voting phase starts
-  - Voting timer now properly cancels when round ends
-- **Memory Leak**: Fixed issue where sessions remained active after game end
-  - Sessions now properly marked inactive when game ends
-  - Sessions now properly removed when empty
-  - Player backups now properly cleaned up
-- **Chat Listener**: Fixed chat listener to work with parallel sessions
-  - Now correctly identifies which session a player is in
-  - Uses session-specific phase manager
-- **Player Join Validation**: Added validation to prevent players from joining:
-  - Full sessions (7 players)
-  - Already started games
-  - Multiple sessions simultaneously
-
-### Changed
-- **Command Permissions**: Updated command access
-  - Normal players can use: `join`, `leave`, `list`
-  - Operators only: `start`, `setspawn`, `setdiscussion`, `begin`, `stop`, `delete`, `debug`
-- **Phase Handlers**: Refactored to support parallel sessions
-  - Each phase handler now manages tasks per session using `Map<String, BukkitTask>`
-  - Timers can be cancelled for specific sessions without affecting others
-- **GameManager**: Major refactoring for parallel session support
-  - Now manages `Map<String, SessionGameContext>` instead of single game state
-  - Methods now take `sessionName` parameter or derive it from player UUID
-  - Added helper methods: `getContext()`, `getContextForPlayer()`, `canPlayerJoinSession()`
-  - Added `emergencyCleanup()` for plugin shutdown
-- **Code Organization**: Refactored into smaller, focused classes
-  - `GameLifecycleManager` fully integrated - handles game/round lifecycle management
-  - `PlayerActionHandler` fully integrated - handles player actions (swipe, cure, vote)
-  - `GameManager` significantly reduced in size and complexity
-
-### Security
-- Added validation to prevent context creation for non-existent sessions
-- Added checks to prevent players from being in multiple sessions
+- Timer reset on phase skip
+- Memory leaks from active sessions
+- Chat listener for parallel sessions
 
 ---
 
-## [0.8-beta] - Previous Version
+## [0.8-beta]
 
 ### Features
-- Core game mechanics (swipe, discussion, voting phases)
-- Role assignment (Spark, Medic, Innocent)
-- Inventory system with paper-based abilities
+- Core game mechanics
+- Role assignment
+- Inventory system
 - Win condition detection
 - Player backup and restore
 - Session management
-

--- a/README.md
+++ b/README.md
@@ -1,333 +1,130 @@
 # Matchbox - Minecraft Social Deduction Game
 
-A paranoia-inducing 7-player social deduction game for Minecraft, inspired by Among Us and designed with recording-proof mechanics.
-
----
-
-## What is Matchbox?
-
-Matchbox is a social deduction game where 7 players work together to identify and eliminate the impostor (Spark) before it's too late. Every player looks identical, and the Spark must eliminate others without being caught. The twist? Everything is recording-proof—even if someone streams their screen, you can't tell who the Spark is!
-
-### Core Concept
-- 7 players enter each round
-- 1 Spark (impostor) tries to eliminate everyone
-- 1 Medic can save infected players
-- 5 Innocents must identify and vote out the Spark
-- 100% recording-safe: Even if someone streams their screen, you can't tell who the Spark is
-
----
-
-## How to Play
-
-### For Players
-
-#### Getting Started
-1. Join a game session using `/matchbox join <session-name>`
-2. Wait for the game to start (admin will use `/matchbox begin`)
-3. You'll be assigned a role: Spark, Medic, or Innocent
-
-#### Your Role
-
-**Spark (Impostor)**
-- Your goal: Eliminate all other players without being caught
-- You can infect one player per round using your ability
-- Use Hunter Vision once per round to see all players
-- Infected players die at the start of the discussion phase
-- Win if you eliminate everyone or if you're not voted out
-
-**Medic**
-- Your goal: Help identify the Spark and save infected players
-- You can cure one infected player per round using your ability
-- Use Healing Sight once per round to see who's infected
-- Save players before they die at the discussion phase
-- Win if the Spark is eliminated
-
-**Innocent**
-- Your goal: Survive and help identify the Spark
-- You have no special abilities
-- Work with others to figure out who the Spark is
-- Vote to eliminate suspicious players
-- Win if the Spark is eliminated
-
-#### Game Phases
-
-**1. Swipe Phase (3 minutes)**
-- Explore the map and interact with other players
-- All players receive identical inventories automatically
-- Spark: Right-click the Swipe paper (above hotbar slot 0) to activate, then right-click a player to infect
-- Medic: Right-click the Healing Touch paper (above hotbar slot 0) to activate, then right-click an infected player to cure
-- Use Hunter Vision (Spark) or Healing Sight (Medic) by right-clicking the paper above hotbar slot 1
-- Use your crossbow and arrow to reveal a player's nametag (one arrow per round)
-- Chat appears as holograms above players' heads (no chat log)
-
-**2. Discussion Phase (30 seconds)**
-- All players are teleported to the discussion area
-- Infected players who weren't cured will die
-- Chat normally to discuss who you think the Spark is
-- Share information and observations
-
-**3. Voting Phase (15 seconds)**
-- Right-click on players to vote for who you think is the Spark
-- The player with the most votes is eliminated
-- Ties are resolved randomly
-- The game continues to the next round
-
-**4. Repeat**
-- The cycle continues until a win condition is met
-
-#### Win Conditions
-
-**Spark Wins:**
-- All other players are eliminated
-- Spark survives until the end
-
-**Innocents & Medic Win:**
-- Spark is eliminated through voting
-- Spark is the last player eliminated
+A 7-player social deduction game for Minecraft with recording-proof mechanics.
 
 ---
 
 ## Installation
 
-### Requirements
-- Minecraft Server: Paper/Spigot 1.21 or higher
-- Java: 21 or higher
-- Players: 2-7 players per game (optimal: 7)
+1. Download `Matchbox.jar` and place it in your server's `plugins/` folder
+2. Restart your server
+3. Configure locations (see Configuration section)
 
-### Setup Steps
-
-1. Download the Plugin
-   - Download the latest Matchbox.jar from releases
-   - Place it in your server's plugins/ folder
-
-2. Restart Your Server
-   - Restart the server to load the plugin
-   - Check the console for "Matchbox has been enabled!"
-
-3. Configure Your Map
-   - Set spawn locations where players will start each round
-   - Set a discussion area where players will meet to vote
+**Requirements**: Paper/Spigot 1.21+, Java 21+, 2-7 players per game
 
 ---
 
 ## Commands
 
-### For Players
+### Player Commands
+- `/matchbox join <session>` - Join a game session
+- `/matchbox leave` - Leave your current session
+- `/matchbox list` - List all active sessions
 
-| Command | Description |
-|---------|-------------|
-| `/matchbox join <session>` | Join a game session |
-| `/matchbox leave` | Leave your current session |
-| `/matchbox list` | List all active sessions |
+**Aliases**: `/mb` or `/mbox`
 
-Aliases: `/mb` or `/mbox` work instead of `/matchbox`
-
-### For Server Admins
-
-| Command | Description |
-|---------|-------------|
-| `/matchbox start <session>` | Create a new game session |
-| `/matchbox setspawn <session>` | Add a spawn location (stand where you want it) |
-| `/matchbox setdiscussion <session>` | Set the discussion area location |
-| `/matchbox begin <session>` | Start the game (requires 2+ players) |
-| `/matchbox stop <session>` | Stop and remove a session |
+### Admin Commands
+- `/matchbox start <session>` - Create a new game session
+- `/matchbox setspawn <session>` - Add a spawn location
+- `/matchbox setseat <session> <number>` - Set a seat location
+- `/matchbox setdiscussion <session>` - Set discussion area location
+- `/matchbox begin <session>` - Start the game
+- `/matchbox stop <session>` - Stop and remove a session
+- `/matchbox skip` - Skip current phase
+- `/matchbox debug` - Show debug info
 
 ---
 
-## Quick Start Guide
+## Configuration
 
-### For Server Admins
+All settings in `plugins/Matchbox/config.yml` (auto-created on first run).
 
-1. Create a Session
-   ```
-   /matchbox start game1
-   ```
+### Setting Up Locations
 
-2. Set Spawn Locations (stand at each location and run):
-   ```
-   /matchbox setspawn game1
-   ```
-   (Repeat 7+ times at different locations)
+**In-Game (Recommended)**
+- Stand at location → `/matchbox setspawn <session>`
+- Stand at seat → `/matchbox setseat <session> <number>`
+- Locations automatically saved to config
 
-3. Set Discussion Area (stand at the discussion area):
-   ```
-   /matchbox setdiscussion game1
-   ```
+**Config File**
+```yaml
+session:
+  spawn-locations:
+    - world: world
+      x: 0.5
+      y: 64.0
+      z: 0.5
 
-4. Have Players Join
-   ```
-   /matchbox join game1
-   ```
+discussion:
+  seat-locations:
+    1:
+      world: world
+      x: 10.5
+      y: 64.0
+      z: 10.5
+```
 
-5. Start the Game (when you have 2+ players):
-   ```
-   /matchbox begin game1
-   ```
-
-6. Stop the Game Anytime
-   ```
-   /matchbox stop game1
-   ```
-
-### For Players
-
-1. Join a Session
-   ```
-   /matchbox join game1
-   ```
-
-2. Wait for the Game to Start
-   - You'll be teleported when the game begins
-   - Your role will be assigned automatically
-
-3. Play the Game
-   - Follow the phase instructions
-   - Use your abilities (if you have any)
-   - Work together to find the Spark!
+### Configurable Settings
+- Phase durations (swipe, discussion, voting)
+- Player limits (min/max)
+- Seat spawn numbers
+- Random skins toggle
 
 ---
 
-## Game Features
+## How to Play
 
-### Recording-Proof Design
-- Identical Inventories: All players have the same items in the same slots
-- Paper-Based Abilities: Abilities are activated by clicking papers (same for everyone)
-- No Unique Items: The Spark doesn't have special items that would show on stream
-- Hologram Chat: Chat appears as holograms during swipe phase (no chat log)
-- Visual Effects: All effects are recording-safe and don't reveal roles
+### Game Phases
 
-### Current Features (v0.9.0)
+**1. Swipe Phase (3 min)**
+- Explore and interact
+- Spark: Infect players
+- Medic: Cure infected players
+- Use abilities (Hunter Vision, Healing Sight)
+- Chat appears as holograms
 
-**Status: Beta Testing Stage** - All core features are implemented and tested. Parallel sessions now supported!
+**2. Discussion Phase (30s)**
+- Teleported to discussion seats
+- Infected players die (if not cured)
+- Discuss and share observations
+- Skins return to normal
 
-**Fully Implemented:**
-- ✅ **Parallel Game Sessions**: Multiple games can run simultaneously without interference
-- ✅ Session management system (create, join, leave, start, stop)
-- ✅ Role assignment (Spark, Medic, Innocent) with proper distribution
-- ✅ Automatic inventory system with identical layouts for all players
-- ✅ Role paper in top rightmost slot (shows your role and description)
-- ✅ Ability papers automatically placed (Swipe/Cure above hotbar slot 0, Vision/Sight above hotbar slot 1)
-- ✅ Fixed crossbow and arrow in hotbar (unmovable, one arrow per round)
-- ✅ Nametag hiding during gameplay (properly restored after game)
-- ✅ Temporary randomized skins applied to active players (restored when game ends)
-- ✅ Hologram-based chat bubbles during swipe phase (no chat log)
-- ✅ Normal chat during discussion and voting phases
-- ✅ Swipe phase with 3-minute timer (configurable in code)
-- ✅ Discussion phase with teleportation (30 seconds, configurable)
-- ✅ Voting phase with right-click voting (15 seconds, configurable)
-- ✅ Paper-based ability system (right-click to activate)
-- ✅ Spark Swipe ability (infect players via paper, 8-second activation window)
-- ✅ Spark Hunter Vision (per-player glow when ProtocolLib is installed, automatic particle fallback otherwise)
-- ✅ Medic Healing Touch (cure infected players, 8-second activation window)
-- ✅ Medic Healing Sight (see infected players via particles, 15 seconds, once per round)
-- ✅ Arrow system for nametag revelation (one per round, separate from swipe)
-- ✅ Infection system with delayed death (applied at discussion start)
-- ✅ Win condition detection (Spark wins, Innocents win)
-- ✅ Player elimination and spectator mode
-- ✅ Player state backup/restoration (inventory, location, health, skins, etc.)
-- ✅ Session cleanup on game end (prevents new rounds after game ends)
-- ✅ Comprehensive defensive programming and error handling
-- ✅ Edge case handling (offline players, 1-2 player games, parallel sessions, etc.)
-- ✅ Memory leak prevention (automatic session termination, proper cleanup)
+**3. Voting Phase (15s)**
+- Right-click players to vote
+- Most votes = eliminated
+- Game continues to next round
 
-**Recent Changes (v0.9.0):**
-- ✅ **Universal Swipe/Cure Indicators**: Subtle particle bursts from Spark swipes and Medic cures are now broadcast to every player, keeping recordings/streams informative without revealing roles.
-- ✅ **Reliable Medic Notifications**: Players who get cured receive a dedicated chat message instead of a title (which previously clashed with phase announcements).
-- ✅ **ProtocolLib Hunter Vision Fix**: Glow packets now use the modern `DataValue` pipeline, preventing client kicks and automatically falling back to particles when packet delivery fails.
-- ✅ **Skin Service Resilience**: Random skin preloading now hits Mojang's public API for proper UUID resolution, eliminating the previous "failed to fetch skin" spam.
-- ✅ **Codebase Polish**: Imports are normalized, documentation updated, and highlight terminology replaces the old “red particles” copy to better match the in-game visuals.
+### Roles
 
-### Planned for Full Release (v1.0)
+**Spark (Impostor)**
+- Eliminate all players without being caught
+- Infect one player per round
+- Use Hunter Vision once per round
 
-**Required:**
-- ⏳ **Configurable Settings**: Customize phase durations and game settings via config.yml
-  - Allow server admins to adjust swipe phase (default: 180s), discussion phase (default: 30s), and voting phase (default: 15s) durations
+**Medic**
+- Identify Spark and save infected players
+- Cure one infected player per round
+- Use Healing Sight once per round
+
+**Innocent**
+- Survive and identify the Spark
+- Work together to vote out suspicious players
 
 ---
 
-## Tips & Strategies
+## Features
 
-### For Spark (Impostor)
-- Blend in with the crowd—act like an innocent
-- Use Hunter Vision strategically to track players
-- Infect players when no one is watching
-- Create suspicion on others during discussion
-- Don't vote suspiciously—try to vote with the majority
-
-### For Medic
-- Use Healing Sight early to identify infected players
-- Save players who are likely to be valuable in voting
-- Share information carefully—don't reveal you're the Medic too early
-- Watch for suspicious behavior during swipe phase
-
-### For Innocents
-- Pay attention to player movements and behavior
-- Use your arrow strategically to reveal someone's nametag (one per round)
-- Share observations during discussion
-- Don't trust anyone completely
-- Vote strategically—eliminate the most suspicious player
-- Work together but stay cautious
+- Parallel sessions (multiple games simultaneously)
+- Recording-proof design (identical inventories/abilities)
+- Full configuration support
+- Automatic location loading from config
+- Damage protection during games
+- Block interaction protection during games
+- Skin system with phase-based restoration
 
 ---
 
-## Known Limitations (Beta)
-
-- **Configuration**: Phase durations are hardcoded (180s swipe, 30s discussion, 15s voting). Config.yml support planned for v1.0
-- **Spectator Teleport**: Eliminated players enter spectator mode but aren't teleported to a spectator area yet (planned for v1.0)
-- **Hunter Vision**: ProtocolLib delivers per-player glow. Without it, the plugin automatically uses particle indicators (logged at startup).
-
-## Parallel Sessions
-
-Starting with v0.8.5-beta, Matchbox supports multiple simultaneous game sessions. This means:
-- Multiple groups can play different games at the same time
-- Each session has its own game state, timers, and players
-- Sessions are completely isolated from each other
-- Memory is properly managed with automatic cleanup
-
----
-
-## Reporting Issues
-
-Found a bug or have a suggestion? Please report it:
-- Create an issue on the project repository
-- Include your Minecraft version and server type
-- Describe what happened and how to reproduce it
-
----
-
-## License
-
-This project is under the MIT license.
-
----
-
-## Credits
-
-Developer: OhACD  
-Version: 0.9.0  
-Minecraft API: 1.21
-
----
-
-## Beta Testing
-
-**Current Status: Beta Testing Stage**
-
-The plugin is feature-complete and ready for beta testing! All core game mechanics are implemented and working. We're looking for feedback on:
-- Game balance and timing
-- User experience and clarity
-- Edge cases and bugs
-- Feature requests
-
-Please report any issues or suggestions!
-
----
-
-"In Matchbox, paranoia isn't a bug—it's the core feature."
-
----
-
-## Additional Resources
-
-- Development Documentation: See DEVELOPMENT.md for technical details, architecture, and development plans
-- For Developers: Check DEVELOPMENT.md for code structure, known issues, and contribution guidelines
+**Version**: 1.0.0  
+**Minecraft API**: 1.21.10  
+**License**: MIT  
+**Developer**: OhACD

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.ohacd'
-version = '0.9.0'
+version = '1.0.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -43,6 +43,8 @@ public final class Matchbox extends JavaPlugin {
         getServer().getPluginManager().registerEvents(
                 new HitRevealListener(gameManager, hologramManager, gameManager.getInventoryManager()), this);
         getServer().getPluginManager().registerEvents(new GameItemProtectionListener(gameManager), this);
+        getServer().getPluginManager().registerEvents(new com.ohacd.matchbox.game.utils.DamageProtectionListener(gameManager), this);
+        getServer().getPluginManager().registerEvents(new com.ohacd.matchbox.game.utils.BlockInteractionProtectionListener(gameManager), this);
 
         // Register ability listeners
         getServer().getPluginManager().registerEvents(new SwipeActivationListener(gameManager, this), this);

--- a/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
@@ -1,0 +1,543 @@
+package com.ohacd.matchbox.game.config;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.Plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Manages the plugin configuration file.
+ */
+public class ConfigManager {
+    private final Plugin plugin;
+    private FileConfiguration config;
+    private File configFile;
+
+    public ConfigManager(Plugin plugin) {
+        this.plugin = plugin;
+        this.configFile = new File(plugin.getDataFolder(), "config.yml");
+        loadConfig();
+    }
+
+    /**
+     * Loads the config file, creating it with defaults if it doesn't exist.
+     */
+    public void loadConfig() {
+        if (!plugin.getDataFolder().exists()) {
+            plugin.getDataFolder().mkdirs();
+        }
+
+        if (!configFile.exists()) {
+            plugin.getLogger().info("Config file not found, creating default config.yml...");
+            try (InputStream defaultConfig = plugin.getResource("config.yml")) {
+                if (defaultConfig != null) {
+                    Files.copy(defaultConfig, configFile.toPath());
+                    plugin.getLogger().info("Default config.yml created successfully.");
+                } else {
+                    plugin.getLogger().warning("Default config.yml not found in resources, creating empty config.");
+                    configFile.createNewFile();
+                }
+            } catch (IOException e) {
+                plugin.getLogger().severe("Failed to create config file: " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
+
+        config = YamlConfiguration.loadConfiguration(configFile);
+        setDefaults();
+        saveConfig();
+    }
+
+    /**
+     * Sets default values for config options.
+     */
+    private void setDefaults() {
+        // Session settings
+        if (!config.contains("session.min-players")) {
+            config.set("session.min-players", 2);
+        }
+        if (!config.contains("session.max-players")) {
+            config.set("session.max-players", 7);
+        }
+        if (!config.contains("session.min-spawn-locations")) {
+            config.set("session.min-spawn-locations", 1);
+        }
+
+        // Swipe phase settings
+        if (!config.contains("swipe.duration")) {
+            config.set("swipe.duration", 180);
+        }
+
+        // Discussion phase settings
+        if (!config.contains("discussion.seat-spawns")) {
+            config.set("discussion.seat-spawns", new ArrayList<>(List.of(1, 2, 3, 4, 5, 6, 7)));
+        }
+        if (!config.contains("discussion.duration")) {
+            config.set("discussion.duration", 30);
+        }
+
+        // Voting phase settings
+        if (!config.contains("voting.duration")) {
+            config.set("voting.duration", 15);
+        }
+
+        // Cosmetic settings
+        if (!config.contains("cosmetics.random-skins-enabled")) {
+            config.set("cosmetics.random-skins-enabled", true);
+        }
+    }
+
+    /**
+     * Saves the config file.
+     */
+    public void saveConfig() {
+        try {
+            config.save(configFile);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Failed to save config file: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Reloads the config file from disk.
+     */
+    public void reloadConfig() {
+        config = YamlConfiguration.loadConfiguration(configFile);
+        setDefaults();
+        saveConfig();
+    }
+
+    /**
+     * Gets the FileConfiguration object.
+     */
+    public FileConfiguration getConfig() {
+        return config;
+    }
+
+    /**
+     * Gets the list of valid seat numbers for discussion phase spawns.
+     * Returns a list of integers representing seat numbers (1-indexed).
+     */
+    public List<Integer> getDiscussionSeatSpawns() {
+        List<?> rawList = config.getList("discussion.seat-spawns");
+        if (rawList == null) {
+            return new ArrayList<>(List.of(1, 2, 3, 4, 5, 6, 7)); // Default
+        }
+
+        List<Integer> seatSpawns = new ArrayList<>();
+        for (Object obj : rawList) {
+            if (obj instanceof Number) {
+                seatSpawns.add(((Number) obj).intValue());
+            } else if (obj instanceof String) {
+                try {
+                    seatSpawns.add(Integer.parseInt((String) obj));
+                } catch (NumberFormatException e) {
+                    plugin.getLogger().warning("Invalid seat number in config: " + obj);
+                }
+            }
+        }
+        return seatSpawns;
+    }
+
+    /**
+     * Gets the discussion phase duration in seconds.
+     * Validates and clamps to reasonable range (5-300 seconds).
+     */
+    public int getDiscussionDuration() {
+        int duration = config.getInt("discussion.duration", 30);
+        if (duration < 5) {
+            plugin.getLogger().warning("Discussion duration too low (" + duration + "), using minimum 5 seconds");
+            return 5;
+        }
+        if (duration > 300) {
+            plugin.getLogger().warning("Discussion duration too high (" + duration + "), using maximum 300 seconds");
+            return 300;
+        }
+        return duration;
+    }
+
+    /**
+     * Gets the swipe phase duration in seconds.
+     * Validates and clamps to reasonable range (30-600 seconds).
+     */
+    public int getSwipeDuration() {
+        int duration = config.getInt("swipe.duration", 180);
+        if (duration < 30) {
+            plugin.getLogger().warning("Swipe duration too low (" + duration + "), using minimum 30 seconds");
+            return 30;
+        }
+        if (duration > 600) {
+            plugin.getLogger().warning("Swipe duration too high (" + duration + "), using maximum 600 seconds");
+            return 600;
+        }
+        return duration;
+    }
+
+    /**
+     * Gets the voting phase duration in seconds.
+     * Validates and clamps to reasonable range (5-120 seconds).
+     */
+    public int getVotingDuration() {
+        int duration = config.getInt("voting.duration", 15);
+        if (duration < 5) {
+            plugin.getLogger().warning("Voting duration too low (" + duration + "), using minimum 5 seconds");
+            return 5;
+        }
+        if (duration > 120) {
+            plugin.getLogger().warning("Voting duration too high (" + duration + "), using maximum 120 seconds");
+            return 120;
+        }
+        return duration;
+    }
+
+    /**
+     * Gets the minimum number of players required to start a game.
+     * Validates and clamps to reasonable range (2-7).
+     */
+    public int getMinPlayers() {
+        int min = config.getInt("session.min-players", 2);
+        if (min < 2) {
+            plugin.getLogger().warning("Min players too low (" + min + "), using minimum 2");
+            return 2;
+        }
+        if (min > 7) {
+            plugin.getLogger().warning("Min players too high (" + min + "), using maximum 7");
+            return 7;
+        }
+        // Ensure min doesn't exceed max (read max directly to avoid recursion)
+        int maxRaw = config.getInt("session.max-players", 7);
+        int max = Math.max(2, Math.min(maxRaw, 20));
+        if (min > max) {
+            plugin.getLogger().warning("Min players (" + min + ") exceeds max players (" + max + "), adjusting min to " + max);
+            return max;
+        }
+        return min;
+    }
+
+    /**
+     * Gets the maximum number of players allowed per session.
+     * Validates and clamps to reasonable range (2-20).
+     */
+    public int getMaxPlayers() {
+        int max = config.getInt("session.max-players", 7);
+        if (max < 2) {
+            plugin.getLogger().warning("Max players too low (" + max + "), using minimum 2");
+            return 2;
+        }
+        if (max > 20) {
+            plugin.getLogger().warning("Max players too high (" + max + "), using maximum 20");
+            return 20;
+        }
+        // Ensure max is at least equal to min (read min directly to avoid recursion)
+        int minRaw = config.getInt("session.min-players", 2);
+        int min = Math.max(2, Math.min(minRaw, 7));
+        if (max < min) {
+            plugin.getLogger().warning("Max players (" + max + ") is less than min players (" + min + "), adjusting max to " + min);
+            return Math.max(min, 2);
+        }
+        return max;
+    }
+
+    /**
+     * Gets the minimum number of spawn locations required before starting a game.
+     * Validates and clamps to reasonable range (1-50).
+     */
+    public int getMinSpawnLocations() {
+        int min = config.getInt("session.min-spawn-locations", 1);
+        if (min < 1) {
+            plugin.getLogger().warning("Min spawn locations too low (" + min + "), using minimum 1");
+            return 1;
+        }
+        if (min > 50) {
+            plugin.getLogger().warning("Min spawn locations too high (" + min + "), using maximum 50");
+            return 50;
+        }
+        return min;
+    }
+
+    /**
+     * Gets whether random skins are enabled.
+     */
+    public boolean isRandomSkinsEnabled() {
+        return config.getBoolean("cosmetics.random-skins-enabled", true);
+    }
+
+    /**
+     * Loads seat locations from config.
+     * Returns a map of seat numbers to locations.
+     */
+    public Map<Integer, Location> loadSeatLocations() {
+        Map<Integer, Location> seatLocations = new HashMap<>();
+        
+        if (!config.contains("discussion.seat-locations")) {
+            return seatLocations;
+        }
+        
+        org.bukkit.configuration.ConfigurationSection seatSection = config.getConfigurationSection("discussion.seat-locations");
+        if (seatSection == null) {
+            return seatLocations;
+        }
+        
+        for (String key : seatSection.getKeys(false)) {
+            try {
+                int seatNumber = Integer.parseInt(key);
+                org.bukkit.configuration.ConfigurationSection locSection = seatSection.getConfigurationSection(key);
+                if (locSection != null) {
+                    Location loc = loadLocationFromSection(locSection);
+                    if (loc != null) {
+                        seatLocations.put(seatNumber, loc);
+                    }
+                }
+            } catch (NumberFormatException e) {
+                plugin.getLogger().warning("Invalid seat number in config: " + key);
+            }
+        }
+        
+        return seatLocations;
+    }
+
+    /**
+     * Saves a seat location to config.
+     */
+    public void saveSeatLocation(int seatNumber, Location location) {
+        if (location == null || location.getWorld() == null) {
+            return;
+        }
+        
+        String path = "discussion.seat-locations." + seatNumber;
+        saveLocationToSection(path, location);
+        saveConfig();
+    }
+
+    /**
+     * Removes a seat location from config.
+     */
+    public void removeSeatLocation(int seatNumber) {
+        config.set("discussion.seat-locations." + seatNumber, null);
+        saveConfig();
+    }
+
+    /**
+     * Loads spawn locations from config.
+     * Returns a list of locations.
+     */
+    public List<Location> loadSpawnLocations() {
+        List<Location> spawnLocations = new ArrayList<>();
+        
+        if (!config.contains("session.spawn-locations")) {
+            return spawnLocations;
+        }
+        
+        List<?> rawList = config.getList("session.spawn-locations");
+        if (rawList == null) {
+            return spawnLocations;
+        }
+        
+        for (Object obj : rawList) {
+            if (obj instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> locMap = (Map<String, Object>) obj;
+                Location loc = loadLocationFromMap(locMap);
+                if (loc != null) {
+                    spawnLocations.add(loc);
+                }
+            }
+        }
+        
+        return spawnLocations;
+    }
+
+    /**
+     * Adds a spawn location to config.
+     */
+    public void addSpawnLocation(Location location) {
+        if (location == null || location.getWorld() == null) {
+            return;
+        }
+        
+        List<Map<String, Object>> spawnList = new ArrayList<>();
+        if (config.contains("session.spawn-locations")) {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> existing = (List<Map<String, Object>>) config.getList("session.spawn-locations");
+            if (existing != null) {
+                spawnList = new ArrayList<>(existing);
+            }
+        }
+        
+        Map<String, Object> locMap = locationToMap(location);
+        spawnList.add(locMap);
+        config.set("session.spawn-locations", spawnList);
+        saveConfig();
+    }
+
+    /**
+     * Clears all spawn locations from config.
+     */
+    public void clearSpawnLocations() {
+        config.set("session.spawn-locations", new ArrayList<>());
+        saveConfig();
+    }
+
+    /**
+     * Removes a spawn location from config by index.
+     */
+    public boolean removeSpawnLocation(int index) {
+        List<?> rawList = config.getList("session.spawn-locations");
+        if (rawList == null || rawList.isEmpty()) {
+            return false;
+        }
+        
+        if (index < 0 || index >= rawList.size()) {
+            return false;
+        }
+        
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> spawnList = new ArrayList<>((List<Map<String, Object>>) rawList);
+        spawnList.remove(index);
+        config.set("session.spawn-locations", spawnList);
+        saveConfig();
+        return true;
+    }
+
+    /**
+     * Gets all seat locations from config as a formatted string for display.
+     */
+    public List<String> getSeatLocationsDisplay() {
+        List<String> display = new ArrayList<>();
+        Map<Integer, Location> seatLocations = loadSeatLocations();
+        
+        if (seatLocations.isEmpty()) {
+            display.add("§7No seat locations configured.");
+            return display;
+        }
+        
+        display.add("§6Seat Locations:");
+        List<Integer> sortedSeats = new ArrayList<>(seatLocations.keySet());
+        sortedSeats.sort(Integer::compareTo);
+        
+        for (Integer seatNum : sortedSeats) {
+            Location loc = seatLocations.get(seatNum);
+            if (loc != null) {
+                display.add(String.format("§7  Seat %d: §e%s §7(%.1f, %.1f, %.1f)", 
+                    seatNum, 
+                    loc.getWorld() != null ? loc.getWorld().getName() : "unknown",
+                    loc.getX(), loc.getY(), loc.getZ()));
+            }
+        }
+        
+        return display;
+    }
+
+    /**
+     * Gets all spawn locations from config as a formatted string for display.
+     */
+    public List<String> getSpawnLocationsDisplay() {
+        List<String> display = new ArrayList<>();
+        List<Location> spawnLocations = loadSpawnLocations();
+        
+        if (spawnLocations.isEmpty()) {
+            display.add("§7No spawn locations configured.");
+            return display;
+        }
+        
+        display.add("§6Spawn Locations:");
+        for (int i = 0; i < spawnLocations.size(); i++) {
+            Location loc = spawnLocations.get(i);
+            if (loc != null) {
+                display.add(String.format("§7  #%d: §e%s §7(%.1f, %.1f, %.1f)", 
+                    i + 1,
+                    loc.getWorld() != null ? loc.getWorld().getName() : "unknown",
+                    loc.getX(), loc.getY(), loc.getZ()));
+            }
+        }
+        
+        return display;
+    }
+
+    /**
+     * Helper method to load a location from a configuration section.
+     */
+    private Location loadLocationFromSection(org.bukkit.configuration.ConfigurationSection section) {
+        String worldName = section.getString("world");
+        if (worldName == null) {
+            return null;
+        }
+        
+        World world = Bukkit.getWorld(worldName);
+        if (world == null) {
+            plugin.getLogger().warning("World '" + worldName + "' not found when loading location from config");
+            return null;
+        }
+        
+        double x = section.getDouble("x", 0.0);
+        double y = section.getDouble("y", 64.0);
+        double z = section.getDouble("z", 0.0);
+        float yaw = (float) section.getDouble("yaw", 0.0);
+        float pitch = (float) section.getDouble("pitch", 0.0);
+        
+        return new Location(world, x, y, z, yaw, pitch);
+    }
+
+    /**
+     * Helper method to load a location from a map.
+     */
+    private Location loadLocationFromMap(Map<String, Object> locMap) {
+        String worldName = (String) locMap.get("world");
+        if (worldName == null) {
+            return null;
+        }
+        
+        World world = Bukkit.getWorld(worldName);
+        if (world == null) {
+            plugin.getLogger().warning("World '" + worldName + "' not found when loading location from config");
+            return null;
+        }
+        
+        double x = ((Number) locMap.getOrDefault("x", 0.0)).doubleValue();
+        double y = ((Number) locMap.getOrDefault("y", 64.0)).doubleValue();
+        double z = ((Number) locMap.getOrDefault("z", 0.0)).doubleValue();
+        float yaw = ((Number) locMap.getOrDefault("yaw", 0.0)).floatValue();
+        float pitch = ((Number) locMap.getOrDefault("pitch", 0.0)).floatValue();
+        
+        return new Location(world, x, y, z, yaw, pitch);
+    }
+
+    /**
+     * Helper method to save a location to a configuration section path.
+     */
+    private void saveLocationToSection(String path, Location location) {
+        config.set(path + ".world", location.getWorld().getName());
+        config.set(path + ".x", location.getX());
+        config.set(path + ".y", location.getY());
+        config.set(path + ".z", location.getZ());
+        config.set(path + ".yaw", location.getYaw());
+        config.set(path + ".pitch", location.getPitch());
+    }
+
+    /**
+     * Helper method to convert a location to a map.
+     */
+    private Map<String, Object> locationToMap(Location location) {
+        Map<String, Object> locMap = new HashMap<>();
+        locMap.put("world", location.getWorld().getName());
+        locMap.put("x", location.getX());
+        locMap.put("y", location.getY());
+        locMap.put("z", location.getZ());
+        locMap.put("yaw", location.getYaw());
+        locMap.put("pitch", location.getPitch());
+        return locMap;
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/cosmetic/SkinManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/cosmetic/SkinManager.java
@@ -154,6 +154,48 @@ public class SkinManager {
         }
     }
 
+    /**
+     * Temporarily restores original skins for players during discussion phase.
+     * Does NOT remove assigned skins, so they can be restored later.
+     */
+    public void restoreOriginalSkinsForDiscussion(Collection<Player> players) {
+        if (players == null || players.isEmpty()) {
+            return;
+        }
+        for (Player player : players) {
+            if (player == null || !player.isOnline()) {
+                continue;
+            }
+            UUID playerId = player.getUniqueId();
+            SkinData original = originalSkins.get(playerId);
+            if (original != null) {
+                setSkin(player, original);
+                refreshAppearance(player);
+            }
+        }
+    }
+
+    /**
+     * Restores assigned skins for players after discussion phase ends.
+     * Uses the assigned skins that were stored when skins were first applied.
+     */
+    public void restoreAssignedSkinsAfterDiscussion(Collection<Player> players) {
+        if (players == null || players.isEmpty()) {
+            return;
+        }
+        for (Player player : players) {
+            if (player == null || !player.isOnline()) {
+                continue;
+            }
+            UUID playerId = player.getUniqueId();
+            SkinData assigned = assignedSkins.get(playerId);
+            if (assigned != null) {
+                setSkin(player, assigned);
+                refreshAppearance(player);
+            }
+        }
+    }
+
     private SkinData pickRandomSkin(UUID playerId) {
         if (cachedSkins.isEmpty()) {
             return null;

--- a/src/main/java/com/ohacd/matchbox/game/session/GameSession.java
+++ b/src/main/java/com/ohacd/matchbox/game/session/GameSession.java
@@ -12,6 +12,7 @@ public class GameSession {
     private final String name;
     private final Set<UUID> players = new HashSet<>();
     private final List<Location> spawnLocations = new ArrayList<>();
+    private final Map<Integer, Location> seatLocations = new HashMap<>();
     private Location discussionLocation;
     private boolean active = false;
 
@@ -192,5 +193,43 @@ public class GameSession {
      */
     public void clearPlayers() {
         players.clear();
+    }
+
+    /**
+     * Sets a seat location for a specific seat number.
+     */
+    public void setSeatLocation(int seatNumber, Location location) {
+        if (location == null || location.getWorld() == null) {
+            seatLocations.remove(seatNumber);
+            return;
+        }
+        seatLocations.put(seatNumber, location.clone());
+    }
+
+    /**
+     * Gets the seat location for a specific seat number.
+     */
+    public Location getSeatLocation(int seatNumber) {
+        Location loc = seatLocations.get(seatNumber);
+        return loc != null ? loc.clone() : null;
+    }
+
+    /**
+     * Gets all seat locations.
+     */
+    public Map<Integer, Location> getSeatLocations() {
+        Map<Integer, Location> result = new HashMap<>();
+        for (Map.Entry<Integer, Location> entry : seatLocations.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().clone());
+        }
+        return result;
+    }
+
+    /**
+     * Checks if a seat location is set for the given seat number.
+     */
+    public boolean hasSeatLocation(int seatNumber) {
+        Location loc = seatLocations.get(seatNumber);
+        return loc != null && loc.getWorld() != null;
     }
 }

--- a/src/main/java/com/ohacd/matchbox/game/utils/BlockInteractionProtectionListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/BlockInteractionProtectionListener.java
@@ -1,0 +1,63 @@
+package com.ohacd.matchbox.game.utils;
+
+import com.ohacd.matchbox.game.GameManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+/**
+ * Prevents players from interacting with blocks during active games.
+ * Only allows interactions with items (for abilities and voting).
+ */
+public class BlockInteractionProtectionListener implements Listener {
+    private final GameManager gameManager;
+
+    public BlockInteractionProtectionListener(GameManager gameManager) {
+        this.gameManager = gameManager;
+    }
+
+    /**
+     * Prevents block interactions during active games.
+     * Allows item interactions (for abilities and voting).
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is in an active game
+        if (!isPlayerInActiveGame(player)) {
+            return;
+        }
+
+        // Allow item interactions (abilities, voting papers, etc.)
+        // These are handled by other listeners
+        if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_AIR) {
+            return;
+        }
+
+        // Block all block interactions (right-click on blocks, left-click on blocks)
+        if (event.getAction() == Action.RIGHT_CLICK_BLOCK || event.getAction() == Action.LEFT_CLICK_BLOCK) {
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Checks if a player is in an active game.
+     */
+    private boolean isPlayerInActiveGame(Player player) {
+        if (player == null || !player.isOnline()) {
+            return false;
+        }
+
+        com.ohacd.matchbox.game.SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
+        if (context == null) {
+            return false;
+        }
+
+        return context.getGameState().isGameActive();
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/utils/DamageProtectionListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/DamageProtectionListener.java
@@ -1,0 +1,101 @@
+package com.ohacd.matchbox.game.utils;
+
+import com.ohacd.matchbox.game.GameManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+
+/**
+ * Prevents players from taking damage or dying during active games.
+ * All damage is cancelled and players are made invulnerable.
+ */
+public class DamageProtectionListener implements Listener {
+    private final GameManager gameManager;
+
+    public DamageProtectionListener(GameManager gameManager) {
+        this.gameManager = gameManager;
+    }
+
+    /**
+     * Prevents all damage to players during active games.
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onEntityDamage(EntityDamageEvent event) {
+        if (!(event.getEntity() instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) event.getEntity();
+        
+        // Check if player is in an active game
+        if (!isPlayerInActiveGame(player)) {
+            return;
+        }
+
+        // Cancel all damage during active games
+        event.setCancelled(true);
+        event.setDamage(0);
+    }
+
+    /**
+     * Prevents player death during active games.
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        
+        // Check if player is in an active game
+        if (!isPlayerInActiveGame(player)) {
+            return;
+        }
+
+        // Prevent death during active games
+        event.setCancelled(true);
+        player.setHealth(player.getMaxHealth());
+        player.setFoodLevel(20);
+        player.setSaturation(20);
+    }
+
+    /**
+     * Prevents hunger loss during active games.
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onFoodLevelChange(FoodLevelChangeEvent event) {
+        if (!(event.getEntity() instanceof Player)) {
+            return;
+        }
+
+        Player player = (Player) event.getEntity();
+        
+        // Check if player is in an active game
+        if (!isPlayerInActiveGame(player)) {
+            return;
+        }
+
+        // Prevent hunger loss during active games
+        event.setCancelled(true);
+        player.setFoodLevel(20);
+        player.setSaturation(20);
+    }
+
+    /**
+     * Checks if a player is in an active game.
+     */
+    private boolean isPlayerInActiveGame(Player player) {
+        if (player == null || !player.isOnline()) {
+            return false;
+        }
+
+        com.ohacd.matchbox.game.SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
+        if (context == null) {
+            return false;
+        }
+
+        return context.getGameState().isGameActive();
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,79 @@
+# Matchbox Plugin Configuration
+
+# Game Session Settings
+session:
+  # Minimum number of players required to start a game
+  min-players: 2
+  
+  # Maximum number of players allowed per session
+  max-players: 7
+  
+  # Minimum number of spawn locations required before starting a game
+  min-spawn-locations: 1
+  
+  # Game spawn locations (coordinates where players spawn at round start)
+  # Can be set via /matchbox setspawn <name> or configured here
+  # Format: world, x, y, z, yaw, pitch
+  spawn-locations: []
+    # Example:
+    # - world: world
+    #   x: 0.5
+    #   y: 64.0
+    #   z: 0.5
+    #   yaw: 0.0
+    #   pitch: 0.0
+
+# Swipe Phase Settings
+swipe:
+  # Swipe phase duration in seconds (default: 180 = 3 minutes)
+  duration: 180
+
+# Discussion Phase Settings
+discussion:
+  # Array of valid seat numbers for discussion phase spawns (1-indexed)
+  # Players will be teleported to these seat locations when discussion starts
+  # Example: [1, 2, 3, 4, 5, 6, 7] means seats 1-7 are valid
+  seat-spawns:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+  
+  # Seat locations (coordinates for each seat)
+  # Can be set via /matchbox setseat <name> <seat-number> or configured here
+  # Format: seat number, then world, x, y, z, yaw, pitch
+  seat-locations: {}
+    # Example:
+    # 1:
+    #   world: world
+    #   x: 10.5
+    #   y: 64.0
+    #   z: 10.5
+    #   yaw: 90.0
+    #   pitch: 0.0
+    # 2:
+    #   world: world
+    #   x: 20.5
+    #   y: 64.0
+    #   z: 20.5
+    #   yaw: 180.0
+    #   pitch: 0.0
+  
+  # Discussion phase duration in seconds
+  duration: 30
+
+# Voting Phase Settings
+voting:
+  # Voting phase duration in seconds
+  duration: 15
+
+# Cosmetic Settings
+cosmetics:
+  # Enable/disable random skin assignment for players during games
+  # When enabled, players will receive random skins at game start
+  # When disabled, players will keep their original skins
+  random-skins-enabled: true
+


### PR DESCRIPTION
## [1.0.0] - Latest Release

### Added
- **Config File Support**: Full configuration system with `config.yml`
  - Configurable phase durations (swipe, discussion, voting)
  - Configurable player limits (min/max players per session)
  - Configurable seat spawn numbers for discussion phase
  - Random skins toggle (enable/disable)
- **Seat Location System**: Discussion phase seat spawns
  - Set seat locations via `/matchbox setseat <session> <number>` command
  - List seat locations via `/matchbox listseatspawns` command
  - Remove set seat locations via `/matchbox removeseat <index>` command
  - Configure seat coordinates in config file
  - Players automatically teleported to seats during discussion
- **Spawn Location Configuration**: Game spawn locations in config
  - Set spawn locations via `/matchbox setspawn <session>` command
  - List spawn locations via `/matchbox listspawns`
  - Remove set spawn locations via `/matchbox removespawn <index>`
  - Configure spawn coordinates in config file
  - Automatic loading from config when sessions don't have locations
- **Skin Restoration System**: Enhanced skin management
  - Player skins return to normal during discussion phase
  - Assigned skins restored after discussion ends
- **Damage Protection**: Players are invulnerable during active games
  - All damage sources blocked (hits, lava, fall damage, etc.)
  - Death prevention during games
  - Hunger loss prevention
- **Block Interaction Protection**: Block interactions disabled during games
  - Right-click and left-click on blocks blocked
  - Item interactions still work (abilities, voting)
- **Config Validation**: Added bound checks to all config values
  - Phase durations: Swipe (30-600s), Discussion (5-300s), Voting (5-120s)
  - Player limits: Min (2-7), Max (2-20) with cross-validation
  - Min spawn locations: (1-50)
  

### Changed
- **Location Management**: Locations can be set via commands or config file
  - Commands automatically save to config
  - Config locations used as defaults for new sessions
- **Phase Durations**: All phase durations configurable via config file
  - Default: Swipe (180s), Discussion (30s), Voting (15s)
- **Player Limits**: Min/max players configurable via config file
  - Default: Min 2, Max 7 players

### Fixed
- Session system cleanup and state management
- Deprecated method usage in leave command
- Discussion/seat location teleportation logic
- Player state restoration on game end
- All commands have been added to tab with proper permission checks