### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 All notable changes to the Matchbox plugin will be documented in this file.
 
-
 ## [0.9.2] - Latest Release (It's all about the base)
+
+This is a quick patch that focuses on cleanup/QOL features and insuring everything works as intended.
+Due to how Skins are handled, the steve skin override falls back to using Alex/Steve skins depending on
+the player model, this will hopefully be handled better next update.
 
 ### Added
 - **Cleaner version handling/project status handling**: Project status and versioning are now handled dynamically
@@ -13,10 +16,13 @@ All notable changes to the Matchbox plugin will be documented in this file.
     - Uses the MessageUtils title pipeline, matching other UI
     - Applies blindness and heavy slowness during the 10s hold, cleared on teleport
     - Works alongside seat teleports and discussion timers
-- **Nickname support**: Voting papers, elimination titles, and hologram reveals now use display names with UUID-backed targeting to remain compatible with nick plugins
+- **Nickname support**: Voting papers, elimination titles, and hologram reveals now use display names with UUID-backed targeting to remain compatible with nick plugins (Dantizzle)
+- **Debug force start**: `/matchbox debugstart <session>` lets admins start a game with fewer than the configured minimum players (still enforces spawn/seat validity)
 
 ### Fixed
-- **Steve skin override**: `cosmetics.use-steve-skins` now reapplies Steve skins for gameplay while restoring players’ original skins during discussion (no more partial overrides)
+- **Steve skin override**: `cosmetics.use-steve-skins` now reapplies Steve skins for gameplay while restoring players’ original skins during discussion (no more partial overrides), currently falls back to Alex skin; will be fixed in the next update (Dantizzle)
+- **Location listing clarity**: `/matchbox listspawns` and `/matchbox listseatspawns` now display all configured entries and mark any with missing/not-loaded worlds instead of reporting none exist
+
 
 ## [0.9.1] - (Config and QOL update)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ All notable changes to the Matchbox plugin will be documented in this file.
 - **Cleaner version handling/project status handling**: Project status and versioning are now handled dynamically
     - The player will get notified if a newer version is available for the plugin
     - Under the hood cleanup for dynamic project status display and project versioning/version checking
-- **Broadcast eliminated player**: Eliminated players get broadcasted to alive players on discussion phase start
-    - Added a long overdue feature where players used to get eliminated silently
-    - Eliminated players now get broadcasted to alive players on discussion phase start
+- **Pre-discussion elimination notice**: Eliminations are now announced as titles 10 seconds before teleporting to discussion
+    - Uses the MessageUtils title pipeline, matching other UI
+    - Applies blindness and heavy slowness during the 10s hold, cleared on teleport
+    - Works alongside seat teleports and discussion timers
+- **Nickname support**: Voting papers, elimination titles, and hologram reveals now use display names with UUID-backed targeting to remain compatible with nick plugins
+
+### Fixed
+- **Steve skin override**: `cosmetics.use-steve-skins` now reapplies Steve skins for gameplay while restoring players’ original skins during discussion (no more partial overrides)
 
 ## [0.9.1] - (Config and QOL update)
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ discussion:
 - Damage protection during games
 - Block interaction protection during games
 - Skin system with phase-based restoration
+- Nickname-friendly UI (titles, voting papers, holograms use player display names)
 - Welcome message system for new players
 
 ---
@@ -157,7 +158,7 @@ Players will also see a welcome message when joining the server with information
 
 ---
 
-**Version**: 0.9.1  
+**Version**: 0.9.2  
 **Minecraft API**: 1.21.10  
 **License**: MIT  
 **Developer**: OhACD

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A 7-player social deduction game for Minecraft with recording-proof mechanics.
 - `/matchbox clearspawns` - Clear all spawn locations (requires confirmation)
 - `/matchbox clearseats` - Clear all seat locations (requires confirmation)
 - `/matchbox begin <session>` - Start the game
+- `/matchbox debugstart <session>` - Force-start a game with debug override (allows starting with fewer than the configured minimum players; still enforces spawn/seat validity)
 - `/matchbox stop <session>` - Stop and remove a session
 - `/matchbox skip` - Skip current phase
 - `/matchbox debug` - Show debug info
@@ -66,6 +67,7 @@ All settings in `plugins/Matchbox/config.yml` (auto-created on first run).
 - Stand at seat → `/matchbox setseat <number>`
 - Locations automatically saved to config and persist across sessions
 - Use `/matchbox listspawns` or `/matchbox listseatspawns` to view configured locations
+  - These commands also flag entries whose worlds are missing or not loaded so you can fix them quickly
 - Use `/matchbox clearspawns` or `/matchbox clearseats` to reset (requires confirmation)
 
 **Config File**

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -33,7 +33,7 @@ import java.util.Set;
  */
 public final class Matchbox extends JavaPlugin {
     // Project status, versioning and update name
-    private static final ProjectStatus projectStatus = ProjectStatus.DEVELOPMENT; // Main toggle for project status
+    private static final ProjectStatus projectStatus = ProjectStatus.STABLE; // Main toggle for project status
     private String updateName = "It's all about the base";
     private String currentVersion;
     private CheckProjectVersion versionChecker;
@@ -81,7 +81,7 @@ public final class Matchbox extends JavaPlugin {
         getCommand("matchbox").setExecutor(commandHandler);
         getCommand("matchbox").setTabCompleter(commandHandler);
 
-        getLogger().info("Matchbox" + currentVersion + "enabled");
+        getLogger().info("Matchbox v" + currentVersion + " enabled");
     }
 
     @Override

--- a/src/main/java/com/ohacd/matchbox/game/cosmetic/SkinManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/cosmetic/SkinManager.java
@@ -50,7 +50,12 @@ public class SkinManager {
         .build();
     private static final Duration PROFILE_TIMEOUT = Duration.ofSeconds(5);
     private static final Pattern PROFILE_ID_PATTERN = Pattern.compile("\"id\"\\s*:\\s*\"([0-9a-fA-F]{32})\"");
-    private static final SkinData DEFAULT_STEVE = new SkinData("", "");
+    // Signed Steve (classic) texture pulled from Mojang session servers.
+    private static final SkinData DEFAULT_STEVE = new SkinData(
+        "ewogICJ0aW1lc3RhbXAiIDogMTcwODk5MzE5MzU2OCwKICAicHJvZmlsZUlkIiA6ICI3ZTU5NzY0MjNjNTQ0ZjM2YjRhMGE0ZTViMTA3YzdmOCIsCiAgInByb2ZpbGVOYW1lIiA6ICJDbGFzc2ljU3RldmUiLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzQ1ZjRmYThjNDIwMmY1YTU4NWJiMDIzMmIxYzYzNzU2ZjJiOGY4YzlmYWZiZjM3ZmZiMDZmMTJhM2Y3NTcwOCIKICAgIH0KICB9Cn0=",
+        "TsDcm/o7blZH0Vt9gnXjASK9SKaKdXt/GAbK6n1h5sqkRLVyg0tutlKJIcLxBvS2Ou81bspUkC3DdEaUBPxURFdKXWyYPUzw+k2OibNFeDtDRv28iIgj2w0+q2vYiSkf0YZMNjyvE+mpWCfX/rVxnJjVt6PL1VZLmy5t/8O1EJe4mqDmCA8EJdlE6zV6TxevYrNAvZbtDYMBRi6S+cbRf8N+SvK9sR8z32cb96UVUsShkLT0sejGMfMZXeENPRdyX0tswrMl2BLJ0XkwpMHosSGQIhvrvCrv0D2GBKZFFKEwiafdUgIT71BnF8sxX2UeCzWbHurRosAvGwYNoM4rZq1ReTTSJ+eUqAZuZtq72kPWBzuKOfVphotphA4NRtZ7mT/IKt1IxFkrnYOuh2DYChCVa5p1Q0lS67ZHrnCIsiZTPeMT6OANil4Y1j/8QcuvG+DBtqFPRNEhPVqOgjaRdjumdFZKvgt9gLxBi82p4tAUnGKxhPeB9XFVQ+dGhDffnZllVuvYDGx+fLOJ3Hj7MfKcsRcm0NdOdaGmVQ6FacGWN/+t7Qu0f8ExhlB62iBygg2uQ4CWmUgCaS6zUzmPa9uCt3xBhVG2G+R/wab8bVfcOltwOXSHhtQ8ZRpjYvuTmtzJ1Rtlm1B5dCQzv0XKnKKwjpVrWzq+q0lQjCDY+o2jsf6qi5hbs="
+    );
+    
 
     private final Plugin plugin;
     private final List<SkinData> cachedSkins = new CopyOnWriteArrayList<>();

--- a/src/main/java/com/ohacd/matchbox/game/utils/PlayerNameUtils.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/PlayerNameUtils.java
@@ -1,0 +1,32 @@
+package com.ohacd.matchbox.game.utils;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Utility helpers for resolving player-facing names with nickname support.
+ * Prefers the Bukkit display name while safely falling back to the real name.
+ */
+@SuppressWarnings("deprecation")
+public final class PlayerNameUtils {
+    private PlayerNameUtils() {}
+
+    /**
+     * Returns the display name if available, otherwise the real player name, or "Unknown" when null.
+     */
+    public static String displayName(Player player) {
+        if (player == null) {
+            return "Unknown";
+        }
+        String display = safeTrim(player.getDisplayName());
+        if (!display.isEmpty()) {
+            return display;
+        }
+        String name = safeTrim(player.getName());
+        return name.isEmpty() ? "Unknown" : name;
+    }
+
+    private static String safeTrim(String input) {
+        return input == null ? "" : input.trim();
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/utils/listeners/HitRevealListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/listeners/HitRevealListener.java
@@ -71,7 +71,7 @@ public class HitRevealListener implements Listener {
         inventoryManager.markArrowUsed(shooter.getUniqueId());
         
         // Reveal player identity for 10 seconds (200 ticks)
-        hologramManager.showTextAbove(target, target.getName(), 200);
+        hologramManager.showTextAbove(target, com.ohacd.matchbox.game.utils.PlayerNameUtils.displayName(target), 200);
         
         // Remove arrow from inventory (they used it)
         shooter.getInventory().setItem(InventoryManager.getArrowHotbarSlot(), null);

--- a/src/main/java/com/ohacd/matchbox/game/utils/listeners/VotePaperListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/listeners/VotePaperListener.java
@@ -4,12 +4,16 @@ import com.ohacd.matchbox.game.GameManager;
 import com.ohacd.matchbox.game.SessionGameContext;
 import com.ohacd.matchbox.game.utils.GamePhase;
 import com.ohacd.matchbox.game.utils.Managers.InventoryManager;
+import com.ohacd.matchbox.game.utils.PlayerNameUtils;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.UUID;
 
 /**
  * Handles voting by right-clicking voting papers during the voting phase.
@@ -57,14 +61,19 @@ public class VotePaperListener implements Listener {
             return;
         }
         
-        // Get target player name from paper
-        String targetName = InventoryManager.getVotingPaperTarget(clicked);
-        if (targetName == null) {
-            return;
+        UUID targetId = InventoryManager.getVotingPaperTargetId(clicked);
+        String targetDisplay = InventoryManager.getVotingPaperTargetDisplay(clicked);
+
+        Player target = null;
+        if (targetId != null) {
+            target = Bukkit.getPlayer(targetId);
         }
-        
-        // Find target player
-        Player target = org.bukkit.Bukkit.getPlayer(targetName);
+        if (target == null && targetDisplay != null) {
+            target = Bukkit.getOnlinePlayers().stream()
+                .filter(p -> targetDisplay.equals(PlayerNameUtils.displayName(p)))
+                .findFirst()
+                .orElse(null);
+        }
         if (target == null || !target.isOnline()) {
             return;
         }


### PR DESCRIPTION
## [0.9.2] - Latest Release (It's all about the base)

This is a small patch that focuses on cleanup/QOL features and insuring everything works as intended.
Due to how Skins are currently handled, the steve skin override falls back to using Alex/Steve skins depending on
the player model, this will hopefully be handled better next update.

### Added
- **Cleaner version handling/project status handling**: Project status and versioning are now handled dynamically
    - The player will get notified if a newer version is available for the plugin
    - Under the hood cleanup for dynamic project status display and project versioning/version checking
- **Pre-discussion elimination notice**: Eliminations are now announced as titles 10 seconds before teleporting to discussion
    - Uses the MessageUtils title pipeline, matching other UI
    - Applies blindness and heavy slowness during the 10s hold, cleared on teleport
    - Works alongside seat teleports and discussion timers
- **Nickname support**: Voting papers, elimination titles, and hologram reveals now use display names with UUID-backed targeting to remain compatible with nick plugins (Dantizzle)
- **Debug force start**: `/matchbox debugstart <session>` lets admins start a game with fewer than the configured minimum players (still enforces spawn/seat validity)

### Fixed
- **Steve skin override**: `cosmetics.use-steve-skins` now reapplies Steve skins for gameplay while restoring players’ original skins during discussion (no more partial overrides), currently falls back to Alex skin; will be fixed in the next update (Dantizzle)
- **Location listing clarity**: `/matchbox listspawns` and `/matchbox listseatspawns` now display all configured entries and mark any with missing/not-loaded worlds instead of reporting none exist
