### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,49 @@
 
 All notable changes to the Matchbox plugin will be documented in this file.
 
-## [0.9.3] - Spark Swap Rotation
+## [0.9.3] - Latest Release (The little quirks of life)
 
 ### Added
-- Spark now rolls a secondary ability each round: Hunter Vision _or_ Spark Swap, alongside Swipe.
-- Spark Swap now occupies the Hunter Vision slot (slot 28) when selected and teleports with preloaded chunks and preserved velocity.
+- **Spark Secondary Ability System**: Spark now rolls a secondary ability each round
+  - Hunter Vision _or_ Spark Swap, alongside Swipe
+  - Spark Swap occupies the Hunter Vision slot (slot 28) when selected
+  - Spark Swap teleports with preloaded chunks and preserved velocity (Designed to be invisible)
+- **Dynamic Voting Threshold System**: Voting thresholds now scale dynamically based on alive player count
+  - Logarithmic scaling between key points: 20 players (20%), 7 players (30%), 3 players and below (50%)
+  - Works for 2-20 players with smooth threshold transitions
+  - Threshold display shown during voting phase: "Threshold: X/Y" (required votes / alive players)
+- **Voting Penalty System**: Penalty applied when voting phases end without elimination
+  - Each phase without elimination reduces the threshold by ~3.33% (configurable)
+  - Maximum penalty of 10% after 3 consecutive no-elimination phases
+  - Penalty resets when a successful elimination occurs
+- **Enhanced Tie Handling**: Ties are now checked against the dynamic threshold
+  - If tie vote count doesn't meet threshold: no elimination occurs
+  - If tie vote count meets threshold: random player from tie is eliminated
+- **Voting Configuration**: All voting threshold values are now configurable in `config.yml`
+  - `voting.threshold.at-20-players` - Threshold percentage at 20 players (default: 0.20)
+  - `voting.threshold.at-7-players` - Threshold percentage at 7 players (default: 0.30)
+  - `voting.threshold.at-3-players` - Threshold percentage at 3 players and below (default: 0.50)
+  - `voting.penalty.per-phase` - Penalty percentage per phase without elimination (default: 0.0333)
+  - `voting.penalty.max-phases` - Maximum phases that accumulate penalty (default: 3)
+  - `voting.penalty.max-reduction` - Maximum penalty reduction percentage (default: 0.10)
 
 ### Changed
-- Ability system routing remains unified; Spark inventories are rebuilt each swipe phase with the chosen secondary.
+- **Ability System Routing**: Ability system routing remains unified; Spark inventories are rebuilt each swipe phase with the chosen secondary
+- **Voting Phase Display**: Actionbar now shows both countdown timer and threshold requirement
+  - Format: "Voting: Xs | Threshold: Y/Z" (timer and required votes / alive players)
+  - Updates every second alongside the countdown timer
+- **Voting Phase Instructions**: Improved voting phase start messages
+  - Removed counter-intuitive "right-click player while holding paper" instruction
+  - Added information that players can choose to not vote
+  - Added threshold requirement display in title subtitle
+  - Added explanation that no elimination occurs if threshold isn't met
+- **Vote Resolution**: Voting now requires meeting the dynamic threshold instead of simple majority
+  - Players see clear feedback when threshold isn't met
+  - System tracks consecutive no-elimination phases for penalty calculation
 
 ---
 
-## [0.9.2] - Latest Release (It's all about the base)
+## [0.9.2] - (It's all about the base)
 
 This is a quick patch that focuses on cleanup/QOL features and insuring everything works as intended.
 Due to how Skins are handled, the steve skin override falls back to using Alex/Steve skins depending on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the Matchbox plugin will be documented in this file.
 - **Dynamic Voting Threshold System**: Voting thresholds now scale dynamically based on alive player count
   - Logarithmic scaling between key points: 20 players (20%), 7 players (30%), 3 players and below (50%)
   - Works for 2-20 players with smooth threshold transitions
-  - Threshold display shown during voting phase: "Threshold: X/Y" (required votes / alive players)
+  - Threshold display shown during voting phase: "Threshold: X/Y" (required votes / alive players) (Dantizzle)
 - **Voting Penalty System**: Penalty applied when voting phases end without elimination
   - Each phase without elimination reduces the threshold by ~3.33% (configurable)
   - Maximum penalty of 10% after 3 consecutive no-elimination phases
@@ -48,6 +48,9 @@ All notable changes to the Matchbox plugin will be documented in this file.
 - **Vote Resolution**: Voting now requires meeting the dynamic threshold instead of simple majority
   - Players see clear feedback when threshold isn't met
   - System tracks consecutive no-elimination phases for penalty calculation
+  
+### Fixed
+- **Steve skin override**: `cosmetics.use-steve-skins` now correctly applies Steve skins to players (Dantizzle)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ All notable changes to the Matchbox plugin will be documented in this file.
   - `voting.penalty.per-phase` - Penalty percentage per phase without elimination (default: 0.0333)
   - `voting.penalty.max-phases` - Maximum phases that accumulate penalty (default: 3)
   - `voting.penalty.max-reduction` - Maximum penalty reduction percentage (default: 0.10)
+- **Spark Ability Configuration**: Spark secondary ability selection is now configurable
+  - `spark.secondary-ability` - Choose Spark ability: "random" (default), "hunter_vision", or "spark_swap"
+  - When set to "random", ability is randomly selected each round (default behavior)
+  - When set to a specific ability, that ability is always used
 
 ### Changed
 - **Ability System Routing**: Ability system routing remains unified; Spark inventories are rebuilt each swipe phase with the chosen secondary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the Matchbox plugin will be documented in this file.
 - **Spark Secondary Ability System**: Spark now rolls a secondary ability each round
   - Hunter Vision _or_ Spark Swap, alongside Swipe
   - Spark Swap occupies the Hunter Vision slot (slot 28) when selected
-  - Spark Swap teleports with preloaded chunks and preserved velocity (Designed to be invisible)
+  - Spark Swap teleports with preloaded chunks, preserved velocity, and preserved look direction (designed to be invisible)
 - **Dynamic Voting Threshold System**: Voting thresholds now scale dynamically based on alive player count
   - Logarithmic scaling between key points: 20 players (20%), 7 players (30%), 3 players and below (50%)
   - Works for 2-20 players with smooth threshold transitions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ All notable changes to the Matchbox plugin will be documented in this file.
   - Added information that players can choose to not vote
   - Added threshold requirement display in title subtitle
   - Added explanation that no elimination occurs if threshold isn't met
+- **Phase Visuals**: Skins are no longer reset to original during discussion/voting, and nametags remain hidden in those phases
+  - Players keep their assigned game skins across phases until swipe starts again
+  - Nametags stay hidden during discussion and voting (revealed only on elimination)
 - **Vote Resolution**: Voting now requires meeting the dynamic threshold instead of simple majority
   - Players see clear feedback when threshold isn't met
   - System tracks consecutive no-elimination phases for penalty calculation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Matchbox plugin will be documented in this file.
 
+## [0.9.3] - Spark Swap Rotation
+
+### Added
+- Spark now rolls a secondary ability each round: Hunter Vision _or_ Spark Swap, alongside Swipe.
+- Spark Swap now occupies the Hunter Vision slot (slot 28) when selected and teleports with preloaded chunks and preserved velocity.
+
+### Changed
+- Ability system routing remains unified; Spark inventories are rebuilt each swipe phase with the chosen secondary.
+
+---
+
 ## [0.9.2] - Latest Release (It's all about the base)
 
 This is a quick patch that focuses on cleanup/QOL features and insuring everything works as intended.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ discussion:
 **Spark (Impostor)**
 - Eliminate all players without being caught
 - Infect one player per round
-- Use Hunter Vision once per round
+ - Each round, you roll one secondary ability: Hunter Vision **or** Spark Swap (teleport swap)
 
 **Medic**
 - Identify Spark and save infected players
@@ -160,7 +160,7 @@ Players will also see a welcome message when joining the server with information
 
 ---
 
-**Version**: 0.9.2  
+**Version**: 0.9.3  
 **Minecraft API**: 1.21.10  
 **License**: MIT  
 **Developer**: OhACD

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Matchbox - Minecraft Social Deduction Game
 
-A 7-player social deduction game for Minecraft with recording-proof mechanics.
+A social deduction game for Minecraft (2-20 players) with recording-proof mechanics.
 
 ---
 
@@ -13,7 +13,7 @@ A 7-player social deduction game for Minecraft with recording-proof mechanics.
    - All spawn locations and seat positions are already set up
    - You can start playing immediately or customize locations as needed
 
-**Requirements**: Paper 1.21.10, Java 21+, 2-7 players per game
+**Requirements**: Paper 1.21.10, Java 21+, 2-20 players per game
 
 ---
 
@@ -55,7 +55,7 @@ All settings in `plugins/Matchbox/config.yml` (auto-created on first run).
 -  11 pre-configured spawn locations
 -  8 pre-configured seat locations for discussion phase
 -  Optimized phase durations (Swipe: 180s, Discussion: 30s, Voting: 15s)
--  Player limits set (Min: 2, Max: 7)
+-  Player limits set (Min: 2, Max: 7, supports up to 20 players)
 -  Random skins enabled by default
 
 **You can start playing immediately without any setup!** The default config works out-of-the-box with the M4tchbox map.
@@ -94,6 +94,14 @@ discussion:
 - Seat spawn numbers
 - Random skins toggle (`cosmetics.random-skins-enabled`)
 - Steve skins option (`cosmetics.use-steve-skins`) - Use default Steve skin for all players
+- **Dynamic Voting Thresholds**:
+  - `voting.threshold.at-20-players` - Threshold at 20 players (default: 0.20 = 20%)
+  - `voting.threshold.at-7-players` - Threshold at 7 players (default: 0.30 = 30%)
+  - `voting.threshold.at-3-players` - Threshold at 3 players and below (default: 0.50 = 50%)
+- **Voting Penalty System**:
+  - `voting.penalty.per-phase` - Penalty per phase without elimination (default: 0.0333 = ~3.33%)
+  - `voting.penalty.max-phases` - Max phases that accumulate penalty (default: 3)
+  - `voting.penalty.max-reduction` - Maximum penalty reduction (default: 0.10 = 10%)
 
 ---
 
@@ -115,8 +123,16 @@ discussion:
 - Skins return to normal
 
 **3. Voting Phase (15s)**
-- Right-click players to vote
-- Most votes = eliminated
+- Right-click or left-click voting papers in your inventory to vote
+- You can choose to not vote (abstain)
+- Dynamic threshold system: Required votes scale based on alive player count
+  - Threshold shown in actionbar: "Threshold: X/Y" (required votes / alive players)
+  - Threshold shown in title subtitle at phase start
+  - Threshold ranges from 20% (20 players) to 50% (3 players and below)
+  - Penalty system: Threshold decreases if voting phases end without elimination
+- Votes must meet threshold for elimination
+- If threshold isn't met, no elimination occurs
+- Ties are resolved by checking if tie vote count meets threshold
 - Game continues to next round
 
 ### Roles
@@ -148,6 +164,7 @@ discussion:
 - Skin system with phase-based restoration
 - Nickname-friendly UI (titles, voting papers, holograms use player display names)
 - Welcome message system for new players
+- **Dynamic voting system** with logarithmic threshold scaling and penalty mechanics
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ discussion:
 **Spark (Impostor)**
 - Eliminate all players without being caught
 - Infect one player per round
- - Each round, you roll one secondary ability: Hunter Vision **or** Spark Swap (teleport swap)
+ - Each round, you roll one secondary ability: Hunter Vision **or** Spark Swap (invisible teleport swap that preserves velocity and look direction)
 
 **Medic**
 - Identify Spark and save infected players

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ discussion:
 - Teleported to discussion seats
 - Infected players die (if not cured)
 - Discuss and share observations
-- Skins return to normal
+- Game skins stay applied; nametags remain hidden
 
 **3. Voting Phase (15s)**
 - Right-click or left-click voting papers in your inventory to vote

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ discussion:
 - Seat spawn numbers
 - Random skins toggle (`cosmetics.random-skins-enabled`)
 - Steve skins option (`cosmetics.use-steve-skins`) - Use default Steve skin for all players
+- **Spark Ability Selection**:
+  - `spark.secondary-ability` - Choose Spark secondary ability: "random" (default), "hunter_vision", or "spark_swap"
+  - "random" - Randomly selects ability each round (default behavior)
+  - "hunter_vision" - Always uses Hunter Vision ability
+  - "spark_swap" - Always uses Spark Swap ability
 - **Dynamic Voting Thresholds**:
   - `voting.threshold.at-20-players` - Threshold at 20 players (default: 0.20 = 20%)
   - `voting.threshold.at-7-players` - Threshold at 7 players (default: 0.30 = 30%)

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.ohacd'
-version = '0.9.2'
+version = '0.9.3'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -5,12 +5,15 @@ import com.ohacd.matchbox.game.GameManager;
 import com.ohacd.matchbox.game.chat.ChatListener;
 import com.ohacd.matchbox.game.hologram.HologramManager;
 import com.ohacd.matchbox.game.session.SessionManager;
-import com.ohacd.matchbox.game.ability.SwipeActivationListener;
-import com.ohacd.matchbox.game.ability.SparkVisionListener;
-import com.ohacd.matchbox.game.ability.SwipeHitListener;
+import com.ohacd.matchbox.game.ability.AbilityEventListener;
+import com.ohacd.matchbox.game.ability.AbilityManager;
 import com.ohacd.matchbox.game.ability.MedicAbilityListener;
 import com.ohacd.matchbox.game.ability.MedicHitListener;
 import com.ohacd.matchbox.game.ability.MedicSightListener;
+import com.ohacd.matchbox.game.ability.SparkSwapAbility;
+import com.ohacd.matchbox.game.ability.SparkVisionListener;
+import com.ohacd.matchbox.game.ability.SwipeActivationListener;
+import com.ohacd.matchbox.game.ability.SwipeHitListener;
 import com.ohacd.matchbox.game.utils.CheckProjectVersion;
 import com.ohacd.matchbox.game.utils.Managers.NameTagManager;
 import com.ohacd.matchbox.game.utils.ProjectStatus;
@@ -42,6 +45,7 @@ public final class Matchbox extends JavaPlugin {
     private HologramManager hologramManager;
     private GameManager gameManager;
     private SessionManager sessionManager;
+    private AbilityManager abilityManager;
 
     @Override
     public void onEnable() {
@@ -49,6 +53,7 @@ public final class Matchbox extends JavaPlugin {
         this.hologramManager = new HologramManager(this);
         this.gameManager = new GameManager(this, hologramManager);
         this.sessionManager = new SessionManager();
+        this.abilityManager = new AbilityManager(gameManager);
         this.versionChecker = new CheckProjectVersion(this);
         this.currentVersion = getInstance().getPluginMeta().getVersion();
 
@@ -60,13 +65,15 @@ public final class Matchbox extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new DamageProtectionListener(gameManager), this);
         getServer().getPluginManager().registerEvents(new BlockInteractionProtectionListener(gameManager), this);
 
-        // Register ability listeners
-        getServer().getPluginManager().registerEvents(new SwipeActivationListener(gameManager, this), this);
-        getServer().getPluginManager().registerEvents(new SwipeHitListener(gameManager), this);
-        getServer().getPluginManager().registerEvents(new SparkVisionListener(gameManager), this);
-        getServer().getPluginManager().registerEvents(new MedicAbilityListener(gameManager, this), this);
-        getServer().getPluginManager().registerEvents(new MedicHitListener(gameManager), this);
-        getServer().getPluginManager().registerEvents(new MedicSightListener(gameManager), this);
+        // Register abilities through a single event router
+        abilityManager.registerAbility(new SwipeActivationListener(gameManager, this));
+        abilityManager.registerAbility(new SwipeHitListener(gameManager));
+        abilityManager.registerAbility(new SparkVisionListener(gameManager));
+        abilityManager.registerAbility(new MedicAbilityListener(gameManager, this));
+        abilityManager.registerAbility(new MedicHitListener(gameManager));
+        abilityManager.registerAbility(new MedicSightListener(gameManager));
+        abilityManager.registerAbility(new SparkSwapAbility(this));
+        getServer().getPluginManager().registerEvents(new AbilityEventListener(abilityManager), this);
 
         // Register voting listeners
         getServer().getPluginManager().registerEvents(new VoteItemListener(gameManager), this);

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -36,8 +36,8 @@ import java.util.Set;
  */
 public final class Matchbox extends JavaPlugin {
     // Project status, versioning and update name
-    private static final ProjectStatus projectStatus = ProjectStatus.DEVELOPMENT; // Main toggle for project status
-    private String updateName = "The little quirks of life";
+    private static final ProjectStatus projectStatus = ProjectStatus.STABLE; // Main toggle for project status
+    private String updateName = "It's the little quirks in life";
     private String currentVersion;
     private CheckProjectVersion versionChecker;
 

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -36,8 +36,8 @@ import java.util.Set;
  */
 public final class Matchbox extends JavaPlugin {
     // Project status, versioning and update name
-    private static final ProjectStatus projectStatus = ProjectStatus.STABLE; // Main toggle for project status
-    private String updateName = "It's all about the base";
+    private static final ProjectStatus projectStatus = ProjectStatus.DEVELOPMENT; // Main toggle for project status
+    private String updateName = "The little quirks of life";
     private String currentVersion;
     private CheckProjectVersion versionChecker;
 

--- a/src/main/java/com/ohacd/matchbox/game/GameManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/GameManager.java
@@ -797,26 +797,16 @@ public class GameManager {
             gameState.removePendingDeath(victimId);
         }
 
-        // Ensure nametags are visible during discussion
+        // Collect alive players for discussion (no nametag/skin changes here)
         Collection<Player> alivePlayersForDiscussion = new ArrayList<>();
         if (alivePlayerIds != null) {
             for (UUID playerId : alivePlayerIds) {
                 if (playerId == null) continue;
                 Player player = getPlayer(playerId);
                 if (player != null && player.isOnline()) {
-                    try {
-                        NameTagManager.showNameTag(player);
-                        alivePlayersForDiscussion.add(player);
-                    } catch (Exception e) {
-                        plugin.getLogger().warning("Failed to show nametag for " + player.getName() + ": " + e.getMessage());
-                    }
+                    alivePlayersForDiscussion.add(player);
                 }
             }
-        }
-
-        // Restore original skins during discussion
-        if (!alivePlayersForDiscussion.isEmpty()) {
-            skinManager.restoreOriginalSkinsForDiscussion(alivePlayersForDiscussion);
         }
 
         // Notify players about eliminated participants and hold them in place before teleport
@@ -1015,11 +1005,6 @@ public class GameManager {
             }
         }
 
-        // Restore assigned skins after discussion ends
-        if (sessionPlayers != null && !sessionPlayers.isEmpty()) {
-            skinManager.restoreAssignedSkinsAfterDiscussion(sessionPlayers);
-        }
-
         // Clear any previous votes
         voteManager.clearVotes();
 
@@ -1057,19 +1042,6 @@ public class GameManager {
                     }
                     // Give ONLY voting papers
                     inventoryManager.giveVotingPapers(player, alivePlayers);
-                }
-            }
-        }
-
-        // Ensure nametags stay visible during voting
-        if (alivePlayers != null) {
-            for (Player player : alivePlayers) {
-                if (player != null && player.isOnline()) {
-                    try {
-                        NameTagManager.showNameTag(player);
-                    } catch (Exception e) {
-                        plugin.getLogger().warning("Failed to show nametag for " + player.getName() + ": " + e.getMessage());
-                    }
                 }
             }
         }

--- a/src/main/java/com/ohacd/matchbox/game/GameManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/GameManager.java
@@ -4,6 +4,7 @@ import com.ohacd.matchbox.Matchbox;
 import com.ohacd.matchbox.game.ability.FallbackHunterVisionAdapter;
 import com.ohacd.matchbox.game.ability.HunterVisionAdapter;
 import com.ohacd.matchbox.game.ability.ProtocolLibHunterVisionAdapter;
+import com.ohacd.matchbox.game.ability.SparkSecondaryAbility;
 import com.ohacd.matchbox.game.action.PlayerActionHandler;
 import com.ohacd.matchbox.game.config.ConfigManager;
 import com.ohacd.matchbox.game.cosmetic.SkinManager;
@@ -37,6 +38,7 @@ import org.bukkit.plugin.Plugin;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.bukkit.Bukkit.getPlayer;
 
@@ -423,6 +425,8 @@ public class GameManager {
         // Setup inventories for all players with their roles (give papers now)
         Collection<Player> alivePlayers = swipePhaseHandler.getAlivePlayerObjects(gameState.getAlivePlayerIds());
         if (alivePlayers != null && !alivePlayers.isEmpty()) {
+            SparkSecondaryAbility sparkAbility = selectSparkSecondaryAbility(gameState);
+
             // Announce phase start only to players in this session
             for (Player p : alivePlayers) {
                 if (p != null && p.isOnline()) {
@@ -437,7 +441,7 @@ public class GameManager {
                     roleMap.put(playerId, role);
                 }
             }
-            inventoryManager.setupInventories(alivePlayers, roleMap);
+            inventoryManager.setupInventories(alivePlayers, roleMap, sparkAbility);
         }
 
         // Hide the name tag for all alive players on phase start
@@ -1763,5 +1767,21 @@ public class GameManager {
 
     public ConfigManager getConfigManager() {
         return configManager;
+    }
+
+    private SparkSecondaryAbility selectSparkSecondaryAbility(GameState gameState) {
+        if (gameState == null) {
+            return SparkSecondaryAbility.HUNTER_VISION;
+        }
+        UUID sparkId = gameState.getSparkUUID();
+        if (sparkId == null) {
+            gameState.setSparkSecondaryAbility(SparkSecondaryAbility.HUNTER_VISION);
+            return SparkSecondaryAbility.HUNTER_VISION;
+        }
+        SparkSecondaryAbility choice = ThreadLocalRandom.current().nextBoolean()
+                ? SparkSecondaryAbility.HUNTER_VISION
+                : SparkSecondaryAbility.SPARK_SWAP;
+        gameState.setSparkSecondaryAbility(choice);
+        return choice;
     }
 }

--- a/src/main/java/com/ohacd/matchbox/game/GameManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/GameManager.java
@@ -1837,9 +1837,28 @@ public class GameManager {
             gameState.setSparkSecondaryAbility(SparkSecondaryAbility.HUNTER_VISION);
             return SparkSecondaryAbility.HUNTER_VISION;
         }
-        SparkSecondaryAbility choice = ThreadLocalRandom.current().nextBoolean()
-                ? SparkSecondaryAbility.HUNTER_VISION
-                : SparkSecondaryAbility.SPARK_SWAP;
+        
+        // Check config for ability selection
+        String configAbility = configManager.getSparkSecondaryAbility();
+        SparkSecondaryAbility choice;
+        
+        if (configAbility.equals("random")) {
+            // Random selection (default behavior)
+            choice = ThreadLocalRandom.current().nextBoolean()
+                    ? SparkSecondaryAbility.HUNTER_VISION
+                    : SparkSecondaryAbility.SPARK_SWAP;
+        } else if (configAbility.equals("hunter_vision")) {
+            choice = SparkSecondaryAbility.HUNTER_VISION;
+        } else if (configAbility.equals("spark_swap")) {
+            choice = SparkSecondaryAbility.SPARK_SWAP;
+        } else {
+            // Fallback to random if invalid config value
+            plugin.getLogger().warning("Invalid Spark ability config value, using random selection");
+            choice = ThreadLocalRandom.current().nextBoolean()
+                    ? SparkSecondaryAbility.HUNTER_VISION
+                    : SparkSecondaryAbility.SPARK_SWAP;
+        }
+        
         gameState.setSparkSecondaryAbility(choice);
         return choice;
     }

--- a/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
+++ b/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
@@ -39,6 +39,9 @@ public class SessionGameContext {
     /** Spawn locations for the current round */
     private List<Location> currentSpawnLocations;
     
+    /** Number of consecutive voting phases that ended without elimination */
+    private int consecutiveNoEliminationPhases = 0;
+    
     public SessionGameContext(Plugin plugin, String sessionName) {
         if (sessionName == null || sessionName.trim().isEmpty()) {
             throw new IllegalArgumentException("Session name cannot be null or empty");
@@ -100,6 +103,29 @@ public class SessionGameContext {
     }
     
     /**
+     * Gets the number of consecutive voting phases that ended without elimination.
+     */
+    public int getConsecutiveNoEliminationPhases() {
+        return consecutiveNoEliminationPhases;
+    }
+    
+    /**
+     * Increments the counter for consecutive no-elimination phases.
+     * Should be called when a voting phase ends without elimination.
+     */
+    public void incrementNoEliminationPhases() {
+        consecutiveNoEliminationPhases++;
+    }
+    
+    /**
+     * Resets the counter for consecutive no-elimination phases.
+     * Should be called when a voting phase ends with elimination.
+     */
+    public void resetNoEliminationPhases() {
+        consecutiveNoEliminationPhases = 0;
+    }
+    
+    /**
      * Cleans up all resources for this session context.
      */
     public void cleanup() {
@@ -107,6 +133,7 @@ public class SessionGameContext {
         activeCureWindow.clear();
         currentDiscussionLocation = null;
         currentSpawnLocations = null;
+        consecutiveNoEliminationPhases = 0;
         gameState.clearGameState();
     }
 }

--- a/src/main/java/com/ohacd/matchbox/game/ability/AbilityEventListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/AbilityEventListener.java
@@ -1,0 +1,35 @@
+package com.ohacd.matchbox.game.ability;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+/**
+ * Single Bukkit listener that forwards relevant events to the registered
+ * abilities through {@link AbilityManager}.
+ */
+public class AbilityEventListener implements Listener {
+    private final AbilityManager abilityManager;
+
+    public AbilityEventListener(AbilityManager abilityManager) {
+        this.abilityManager = abilityManager;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        abilityManager.handleInventoryClick(event);
+    }
+
+    @EventHandler
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        abilityManager.handlePlayerInteract(event);
+    }
+
+    @EventHandler
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        abilityManager.handlePlayerInteractEntity(event);
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/ability/AbilityHandler.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/AbilityHandler.java
@@ -1,0 +1,18 @@
+package com.ohacd.matchbox.game.ability;
+
+import com.ohacd.matchbox.game.SessionGameContext;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+/**
+ * Minimal contract for ability handlers so a single listener can route events.
+ */
+public interface AbilityHandler {
+    default void handleInventoryClick(InventoryClickEvent event, SessionGameContext context) { }
+
+    default void handlePlayerInteract(PlayerInteractEvent event, SessionGameContext context) { }
+
+    default void handlePlayerInteractEntity(PlayerInteractEntityEvent event, SessionGameContext context) { }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/ability/AbilityManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/AbilityManager.java
@@ -1,0 +1,108 @@
+package com.ohacd.matchbox.game.ability;
+
+import com.ohacd.matchbox.game.GameManager;
+import com.ohacd.matchbox.game.SessionGameContext;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Central registry and dispatcher for all abilities so we only maintain one
+ * Bukkit listener. Abilities remain self contained while sharing the same
+ * routing logic.
+ */
+public class AbilityManager {
+    private final GameManager gameManager;
+    private final List<AbilityHandler> abilities = new ArrayList<>();
+
+    public AbilityManager(GameManager gameManager) {
+        this.gameManager = gameManager;
+    }
+
+    public void registerAbility(AbilityHandler ability) {
+        if (ability != null) {
+            abilities.add(ability);
+        }
+    }
+
+    public List<AbilityHandler> getAbilities() {
+        return Collections.unmodifiableList(abilities);
+    }
+
+    public void handleInventoryClick(InventoryClickEvent event) {
+        Player player = getPlayer(event.getWhoClicked());
+        if (player == null) {
+            return;
+        }
+        SessionGameContext context = getContext(player.getUniqueId());
+        if (context == null) {
+            return;
+        }
+        for (AbilityHandler ability : abilities) {
+            ability.handleInventoryClick(event, context);
+            if (event.isCancelled()) {
+                break;
+            }
+        }
+    }
+
+    public void handlePlayerInteract(PlayerInteractEvent event) {
+        Player player = getPlayer(event.getPlayer());
+        if (player == null) {
+            return;
+        }
+        SessionGameContext context = getContext(player.getUniqueId());
+        if (context == null) {
+            return;
+        }
+        for (AbilityHandler ability : abilities) {
+            ability.handlePlayerInteract(event, context);
+            if (event.useInteractedBlock() == Event.Result.DENY || event.useItemInHand() == Event.Result.DENY) {
+                break;
+            }
+        }
+    }
+
+    public void handlePlayerInteractEntity(PlayerInteractEntityEvent event) {
+        Player player = getPlayer(event.getPlayer());
+        if (player == null) {
+            return;
+        }
+        SessionGameContext context = getContext(player.getUniqueId());
+        if (context == null) {
+            return;
+        }
+        for (AbilityHandler ability : abilities) {
+            ability.handlePlayerInteractEntity(event, context);
+            if (event.isCancelled()) {
+                break;
+            }
+        }
+    }
+
+    private SessionGameContext getContext(UUID playerId) {
+        SessionGameContext context = gameManager.getContextForPlayer(playerId);
+        if (context == null) {
+            return null;
+        }
+        if (!context.getGameState().isGameActive()) {
+            return null;
+        }
+        return context;
+    }
+
+    private Player getPlayer(Object maybePlayer) {
+        if (maybePlayer instanceof Player) {
+            return (Player) maybePlayer;
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/ability/MedicAbilityListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/MedicAbilityListener.java
@@ -8,8 +8,6 @@ import com.ohacd.matchbox.game.utils.GamePhase;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -22,7 +20,7 @@ import org.bukkit.scheduler.BukkitRunnable;
  * Supports right-click and left-click in inventory, and right-click when held in main hand.
  * Silent by design (no messages/holograms).
  */
-public class MedicAbilityListener implements Listener {
+public class MedicAbilityListener implements AbilityHandler {
     private final GameManager gameManager;
     private final Plugin plugin;
 
@@ -31,22 +29,11 @@ public class MedicAbilityListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
+    @Override
+    public void handleInventoryClick(InventoryClickEvent event, SessionGameContext context) {
         if (!(event.getWhoClicked() instanceof Player)) return;
         
         Player player = (Player) event.getWhoClicked();
-        
-        // Get session context for this player
-        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
-        if (context == null) {
-            return; // Player not in any active game
-        }
-        
-        // Game must be active
-        if (!context.getGameState().isGameActive()) {
-            return;
-        }
         
         // Check if clicking the cure paper slot
         int slot = event.getSlot();
@@ -113,8 +100,8 @@ public class MedicAbilityListener implements Listener {
         }.runTaskLater(plugin, 8L * 20L);
     }
     
-    @EventHandler
-    public void onPlayerInteract(PlayerInteractEvent event) {
+    @Override
+    public void handlePlayerInteract(PlayerInteractEvent event, SessionGameContext context) {
         // Only handle right-click with item in hand (not block interactions)
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
@@ -125,17 +112,6 @@ public class MedicAbilityListener implements Listener {
         
         // Check if holding paper in main hand
         if (heldItem == null || heldItem.getType() != Material.PAPER) {
-            return;
-        }
-        
-        // Get session context for this player
-        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
-        if (context == null) {
-            return; // Player not in any active game
-        }
-        
-        // Game must be active
-        if (!context.getGameState().isGameActive()) {
             return;
         }
         

--- a/src/main/java/com/ohacd/matchbox/game/ability/MedicHitListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/MedicHitListener.java
@@ -4,37 +4,24 @@ import com.ohacd.matchbox.game.GameManager;
 import com.ohacd.matchbox.game.SessionGameContext;
 import com.ohacd.matchbox.game.utils.GamePhase;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 /**
  * Detects right-clicks on other players and forwards to GameManager.handleCure()
  * only when the medic's cure window is active. Silent; no feedback shown.
  */
-public class MedicHitListener implements Listener {
+public class MedicHitListener implements AbilityHandler {
     private final GameManager gameManager;
 
     public MedicHitListener(GameManager gameManager) {
         this.gameManager = gameManager;
     }
 
-    @EventHandler
-    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+    @Override
+    public void handlePlayerInteractEntity(PlayerInteractEntityEvent event, SessionGameContext context) {
         if (!(event.getRightClicked() instanceof Player)) return;
         Player medic = event.getPlayer();
         Player target = (Player) event.getRightClicked();
-
-        // Get session context for this player
-        SessionGameContext context = gameManager.getContextForPlayer(medic.getUniqueId());
-        if (context == null) {
-            return; // Player not in any active game
-        }
-        
-        // Game must be active
-        if (!context.getGameState().isGameActive()) {
-            return;
-        }
 
         // Only allow during swipe phase
         if (!context.getPhaseManager().isPhase(GamePhase.SWIPE)) return;

--- a/src/main/java/com/ohacd/matchbox/game/ability/MedicSightListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/MedicSightListener.java
@@ -8,8 +8,6 @@ import com.ohacd.matchbox.game.utils.GamePhase;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -21,29 +19,18 @@ import org.bukkit.inventory.ItemStack;
  * Shows subtle highlight particles on all infected players for 15 seconds (only visible to medic).
  * Silent by design (no messages/holograms).
  */
-public class MedicSightListener implements Listener {
+public class MedicSightListener implements AbilityHandler {
     private final GameManager gameManager;
 
     public MedicSightListener(GameManager gameManager) {
         this.gameManager = gameManager;
     }
 
-    @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
+    @Override
+    public void handleInventoryClick(InventoryClickEvent event, SessionGameContext context) {
         if (!(event.getWhoClicked() instanceof Player)) return;
         
         Player player = (Player) event.getWhoClicked();
-        
-        // Get session context for this player
-        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
-        if (context == null) {
-            return; // Player not in any active game
-        }
-        
-        // Game must be active
-        if (!context.getGameState().isGameActive()) {
-            return;
-        }
         
         // Check if clicking the sight paper slot
         int slot = event.getSlot();
@@ -88,8 +75,8 @@ public class MedicSightListener implements Listener {
         player.updateInventory();
     }
     
-    @EventHandler
-    public void onPlayerInteract(PlayerInteractEvent event) {
+    @Override
+    public void handlePlayerInteract(PlayerInteractEvent event, SessionGameContext context) {
         // Only handle right-click with item in hand (not block interactions)
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
@@ -100,17 +87,6 @@ public class MedicSightListener implements Listener {
         
         // Check if holding paper in main hand
         if (heldItem == null || heldItem.getType() != Material.PAPER) {
-            return;
-        }
-        
-        // Get session context for this player
-        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
-        if (context == null) {
-            return; // Player not in any active game
-        }
-        
-        // Game must be active
-        if (!context.getGameState().isGameActive()) {
             return;
         }
         

--- a/src/main/java/com/ohacd/matchbox/game/ability/SparkSecondaryAbility.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/SparkSecondaryAbility.java
@@ -1,0 +1,10 @@
+package com.ohacd.matchbox.game.ability;
+
+/**
+ * Tracks which secondary Spark ability is active for the current round.
+ */
+public enum SparkSecondaryAbility {
+    HUNTER_VISION,
+    SPARK_SWAP
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/ability/SparkSwapAbility.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/SparkSwapAbility.java
@@ -1,0 +1,211 @@
+package com.ohacd.matchbox.game.ability;
+
+import com.ohacd.matchbox.game.SessionGameContext;
+import com.ohacd.matchbox.game.state.GameState;
+import com.ohacd.matchbox.game.utils.GamePhase;
+import com.ohacd.matchbox.game.utils.Managers.InventoryManager;
+import com.ohacd.matchbox.game.utils.Role;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Spark-only ability that swaps the Spark with a random alive player. Designed
+ * to be invisible by preloading chunks and synchronising teleports within the
+ * same tick while preserving velocity.
+ */
+public class SparkSwapAbility implements AbilityHandler {
+    private final Plugin plugin;
+    private final Random random = new Random();
+
+    public SparkSwapAbility(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void handleInventoryClick(InventoryClickEvent event, SessionGameContext context) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+        Player player = (Player) event.getWhoClicked();
+        if (!isSparkSwapActive(context, player.getUniqueId())) {
+            return;
+        }
+
+        int slot = event.getSlot();
+        int rawSlot = event.getRawSlot();
+        if (slot != InventoryManager.getVisionSightPaperSlot() && rawSlot != InventoryManager.getVisionSightPaperSlot()) {
+            return;
+        }
+        if (event.getClickedInventory() == null) {
+            return;
+        }
+
+        ItemStack clicked = event.getCurrentItem();
+        if (!isSwapPaper(clicked)) {
+            return;
+        }
+
+        event.setCancelled(true);
+        attemptSwap(player, context, clicked);
+    }
+
+    @Override
+    public void handlePlayerInteract(PlayerInteractEvent event, SessionGameContext context) {
+        Player player = event.getPlayer();
+        if (!isSparkSwapActive(context, player.getUniqueId())) {
+            return;
+        }
+
+        switch (event.getAction()) {
+            case RIGHT_CLICK_AIR:
+            case RIGHT_CLICK_BLOCK:
+                break;
+            default:
+                return;
+        }
+
+        ItemStack heldItem = player.getInventory().getItemInMainHand();
+        if (!isSwapPaper(heldItem)) {
+            return;
+        }
+        ItemStack slotItem = player.getInventory().getItem(InventoryManager.getVisionSightPaperSlot());
+        if (slotItem == null || !slotItem.equals(heldItem)) {
+            return;
+        }
+
+        event.setCancelled(true);
+        attemptSwap(player, context, heldItem);
+    }
+
+    private boolean isSparkSwapActive(SessionGameContext context, UUID playerId) {
+        if (context == null || playerId == null) {
+            return false;
+        }
+        GameState gameState = context.getGameState();
+        if (!context.getPhaseManager().isPhase(GamePhase.SWIPE)) {
+            return false;
+        }
+        if (gameState.getRole(playerId) != Role.SPARK) {
+            return false;
+        }
+        return gameState.getSparkSecondaryAbility() == SparkSecondaryAbility.SPARK_SWAP;
+    }
+
+    private boolean isSwapPaper(ItemStack item) {
+        return item != null && item.getType() == Material.PAPER;
+    }
+
+    private void attemptSwap(Player spark, SessionGameContext context, ItemStack triggerItem) {
+        GameState gameState = context.getGameState();
+        UUID sparkId = spark.getUniqueId();
+        if (gameState.hasUsedSparkSwapThisRound(sparkId)) {
+            return;
+        }
+
+        Player target = pickRandomTarget(context, sparkId);
+        if (target == null) {
+            return;
+        }
+
+        gameState.markUsedSparkSwap(sparkId);
+        markPaperAsUsed(spark, triggerItem);
+
+        Location sparkLoc = spark.getLocation().clone();
+        Location targetLoc = target.getLocation().clone();
+        Vector sparkVelocity = spark.getVelocity().clone();
+        Vector targetVelocity = target.getVelocity().clone();
+
+        CompletableFuture<Void> sparkChunk = ensureChunkLoaded(sparkLoc);
+        CompletableFuture<Void> targetChunk = ensureChunkLoaded(targetLoc);
+
+        CompletableFuture.allOf(sparkChunk, targetChunk).whenComplete((ignored, throwable) ->
+            Bukkit.getScheduler().runTask(plugin, () -> performSwap(spark, target, sparkLoc, targetLoc, sparkVelocity, targetVelocity))
+        );
+    }
+
+    private Player pickRandomTarget(SessionGameContext context, UUID sparkId) {
+        List<Player> candidates = new ArrayList<>();
+        for (UUID uuid : context.getGameState().getAlivePlayerIds()) {
+            if (uuid == null || uuid.equals(sparkId)) {
+                continue;
+            }
+            Player candidate = Bukkit.getPlayer(uuid);
+            if (candidate != null && candidate.isOnline()) {
+                candidates.add(candidate);
+            }
+        }
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        return candidates.get(random.nextInt(candidates.size()));
+    }
+
+    private CompletableFuture<Void> ensureChunkLoaded(Location location) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        if (location == null || location.getWorld() == null) {
+            future.complete(null);
+            return future;
+        }
+        Bukkit.getScheduler().runTask(plugin, () -> {
+            try {
+                if (!location.getChunk().isLoaded()) {
+                    location.getChunk().load(true);
+                }
+                future.complete(null);
+            } catch (Exception ex) {
+                future.completeExceptionally(ex);
+            }
+        });
+        return future;
+    }
+
+    private void performSwap(Player spark, Player target, Location sparkLoc, Location targetLoc, Vector sparkVelocity, Vector targetVelocity) {
+        if (spark == null || target == null || !spark.isOnline() || !target.isOnline()) {
+            return;
+        }
+
+        try {
+            Location sparkDest = targetLoc.clone();
+            sparkDest.setYaw(spark.getLocation().getYaw());
+            sparkDest.setPitch(spark.getLocation().getPitch());
+
+            Location targetDest = sparkLoc.clone();
+            targetDest.setYaw(target.getLocation().getYaw());
+            targetDest.setPitch(target.getLocation().getPitch());
+
+            spark.teleport(sparkDest);
+            target.teleport(targetDest);
+
+            spark.setVelocity(targetVelocity);
+            target.setVelocity(sparkVelocity);
+
+            spark.setFallDistance(0f);
+            target.setFallDistance(0f);
+        } catch (Exception ex) {
+            plugin.getLogger().warning("Spark Swap failed: " + ex.getMessage());
+        }
+    }
+
+    private void markPaperAsUsed(Player spark, ItemStack triggerItem) {
+        if (spark == null || triggerItem == null) {
+            return;
+        }
+        ItemStack usedIndicator = InventoryManager.createUsedIndicator(triggerItem);
+        spark.getInventory().setItem(InventoryManager.getVisionSightPaperSlot(), usedIndicator);
+        spark.updateInventory();
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/ability/SparkVisionListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/SparkVisionListener.java
@@ -8,30 +8,26 @@ import com.ohacd.matchbox.game.utils.GamePhase;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import com.ohacd.matchbox.game.ability.SparkSecondaryAbility;
 
 /**
  * Activates Hunter Vision when a Spark clicks a PAPER in slot 28 (above hotbar slot 1).
  */
-public class SparkVisionListener implements Listener {
+public class SparkVisionListener implements AbilityHandler {
     private final GameManager gameManager;
 
     public SparkVisionListener(GameManager gameManager) {
         this.gameManager = gameManager;
     }
 
-    @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
+    @Override
+    public void handleInventoryClick(InventoryClickEvent event, SessionGameContext context) {
         if (!(event.getWhoClicked() instanceof Player)) return;
         Player player = (Player) event.getWhoClicked();
-        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
-        if (context == null) return;
-        if (!context.getGameState().isGameActive()) return;
 
         int slot = event.getSlot();
         int rawSlot = event.getRawSlot();
@@ -40,6 +36,7 @@ public class SparkVisionListener implements Listener {
 
         ItemStack clicked = event.getCurrentItem();
         if (clicked == null || clicked.getType() != Material.PAPER) return;
+        if (context.getGameState().getSparkSecondaryAbility() != SparkSecondaryAbility.HUNTER_VISION) return;
         if (!context.getPhaseManager().isPhase(GamePhase.SWIPE)) return;
         if (context.getGameState().getRole(player.getUniqueId()) != Role.SPARK) return;
         if (context.getGameState().hasUsedHunterVisionThisRound(player.getUniqueId())) return;
@@ -52,19 +49,16 @@ public class SparkVisionListener implements Listener {
         player.updateInventory();
     }
 
-    @EventHandler
-    public void onPlayerInteract(PlayerInteractEvent event) {
+    @Override
+    public void handlePlayerInteract(PlayerInteractEvent event, SessionGameContext context) {
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
         Player player = event.getPlayer();
         ItemStack heldItem = player.getInventory().getItemInMainHand();
         if (heldItem == null || heldItem.getType() != Material.PAPER) return;
 
-        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
-        if (context == null) return;
-        if (!context.getGameState().isGameActive()) return;
-
         ItemStack slot28Item = player.getInventory().getItem(InventoryManager.getVisionSightPaperSlot());
         if (slot28Item == null || slot28Item.getType() != Material.PAPER || !slot28Item.equals(heldItem)) return;
+        if (context.getGameState().getSparkSecondaryAbility() != SparkSecondaryAbility.HUNTER_VISION) return;
         if (!context.getPhaseManager().isPhase(GamePhase.SWIPE)) return;
         if (context.getGameState().getRole(player.getUniqueId()) != Role.SPARK) return;
         if (context.getGameState().hasUsedHunterVisionThisRound(player.getUniqueId())) return;

--- a/src/main/java/com/ohacd/matchbox/game/ability/SwipeActivationListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/SwipeActivationListener.java
@@ -8,8 +8,6 @@ import com.ohacd.matchbox.game.utils.GamePhase;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -22,7 +20,7 @@ import org.bukkit.scheduler.BukkitRunnable;
  * Supports right-click and left-click in inventory, and right-click when held in main hand.
  * Silent by design (no messages/holograms).
  */
-public class SwipeActivationListener implements Listener {
+public class SwipeActivationListener implements AbilityHandler {
     private final GameManager gameManager;
     private final Plugin plugin;
 
@@ -31,22 +29,11 @@ public class SwipeActivationListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler
-    public void onInventoryClick(InventoryClickEvent event) {
+    @Override
+    public void handleInventoryClick(InventoryClickEvent event, SessionGameContext context) {
         if (!(event.getWhoClicked() instanceof Player)) return;
         
         Player player = (Player) event.getWhoClicked();
-        
-        // Get session context for this player
-        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
-        if (context == null) {
-            return; // Player not in any active game
-        }
-        
-        // Game must be active
-        if (!context.getGameState().isGameActive()) {
-            return;
-        }
         
         // Check if clicking the swipe paper slot
         int slot = event.getSlot();
@@ -108,8 +95,8 @@ public class SwipeActivationListener implements Listener {
         }.runTaskLater(plugin, 8L * 20L);
     }
     
-    @EventHandler
-    public void onPlayerInteract(PlayerInteractEvent event) {
+    @Override
+    public void handlePlayerInteract(PlayerInteractEvent event, SessionGameContext context) {
         // Only handle right-click with item in hand (not block interactions)
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
@@ -120,17 +107,6 @@ public class SwipeActivationListener implements Listener {
         
         // Check if holding paper in main hand
         if (heldItem == null || heldItem.getType() != Material.PAPER) {
-            return;
-        }
-        
-        // Get session context for this player
-        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
-        if (context == null) {
-            return; // Player not in any active game
-        }
-        
-        // Game must be active
-        if (!context.getGameState().isGameActive()) {
             return;
         }
         

--- a/src/main/java/com/ohacd/matchbox/game/ability/SwipeHitListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/SwipeHitListener.java
@@ -4,37 +4,24 @@ import com.ohacd.matchbox.game.GameManager;
 import com.ohacd.matchbox.game.SessionGameContext;
 import com.ohacd.matchbox.game.utils.GamePhase;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 /**
  * Detects right-clicks on other players and forwards to GameManager.handleSwipe()
  * only when the shooter's swipe window is active. Silent; no feedback shown.
  */
-public class SwipeHitListener implements Listener {
+public class SwipeHitListener implements AbilityHandler {
     private final GameManager gameManager;
 
     public SwipeHitListener(GameManager gameManager) {
         this.gameManager = gameManager;
     }
 
-    @EventHandler
-    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+    @Override
+    public void handlePlayerInteractEntity(PlayerInteractEntityEvent event, SessionGameContext context) {
         if (!(event.getRightClicked() instanceof Player)) return;
         Player attacker = event.getPlayer();
         Player target = (Player) event.getRightClicked();
-
-        // Get session context for this player
-        SessionGameContext context = gameManager.getContextForPlayer(attacker.getUniqueId());
-        if (context == null) {
-            return; // Player not in any active game
-        }
-        
-        // Game must be active
-        if (!context.getGameState().isGameActive()) {
-            return;
-        }
 
         // Only allow during swipe phase
         if (!context.getPhaseManager().isPhase(GamePhase.SWIPE)) return;

--- a/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
@@ -91,6 +91,28 @@ public class ConfigManager {
         if (!config.contains("voting.duration")) {
             config.set("voting.duration", 15);
         }
+        
+        // Dynamic voting threshold settings
+        if (!config.contains("voting.threshold.at-20-players")) {
+            config.set("voting.threshold.at-20-players", 0.20); // 20%
+        }
+        if (!config.contains("voting.threshold.at-7-players")) {
+            config.set("voting.threshold.at-7-players", 0.30); // 30%
+        }
+        if (!config.contains("voting.threshold.at-3-players")) {
+            config.set("voting.threshold.at-3-players", 0.50); // 50%
+        }
+        
+        // Voting penalty settings (for phases without elimination)
+        if (!config.contains("voting.penalty.per-phase")) {
+            config.set("voting.penalty.per-phase", 0.0333); // ~3.33% per phase
+        }
+        if (!config.contains("voting.penalty.max-phases")) {
+            config.set("voting.penalty.max-phases", 3); // Max 3 phases
+        }
+        if (!config.contains("voting.penalty.max-reduction")) {
+            config.set("voting.penalty.max-reduction", 0.10); // 10% max reduction
+        }
 
         // Cosmetic settings
         if (!config.contains("cosmetics.random-skins-enabled")) {
@@ -283,6 +305,108 @@ public class ConfigManager {
      */
     public boolean isUseSteveSkins() {
         return config.getBoolean("cosmetics.use-steve-skins", false);
+    }
+    
+    /**
+     * Gets the voting threshold percentage at 20 players.
+     * Validates and clamps to reasonable range (0.05-1.0).
+     */
+    public double getVotingThresholdAt20Players() {
+        double threshold = config.getDouble("voting.threshold.at-20-players", 0.20);
+        if (threshold < 0.05) {
+            plugin.getLogger().warning("Voting threshold at 20 players too low (" + threshold + "), using minimum 0.05");
+            return 0.05;
+        }
+        if (threshold > 1.0) {
+            plugin.getLogger().warning("Voting threshold at 20 players too high (" + threshold + "), using maximum 1.0");
+            return 1.0;
+        }
+        return threshold;
+    }
+    
+    /**
+     * Gets the voting threshold percentage at 7 players.
+     * Validates and clamps to reasonable range (0.05-1.0).
+     */
+    public double getVotingThresholdAt7Players() {
+        double threshold = config.getDouble("voting.threshold.at-7-players", 0.30);
+        if (threshold < 0.05) {
+            plugin.getLogger().warning("Voting threshold at 7 players too low (" + threshold + "), using minimum 0.05");
+            return 0.05;
+        }
+        if (threshold > 1.0) {
+            plugin.getLogger().warning("Voting threshold at 7 players too high (" + threshold + "), using maximum 1.0");
+            return 1.0;
+        }
+        return threshold;
+    }
+    
+    /**
+     * Gets the voting threshold percentage at 3 players and below.
+     * Validates and clamps to reasonable range (0.05-1.0).
+     */
+    public double getVotingThresholdAt3Players() {
+        double threshold = config.getDouble("voting.threshold.at-3-players", 0.50);
+        if (threshold < 0.05) {
+            plugin.getLogger().warning("Voting threshold at 3 players too low (" + threshold + "), using minimum 0.05");
+            return 0.05;
+        }
+        if (threshold > 1.0) {
+            plugin.getLogger().warning("Voting threshold at 3 players too high (" + threshold + "), using maximum 1.0");
+            return 1.0;
+        }
+        return threshold;
+    }
+    
+    /**
+     * Gets the penalty percentage applied per voting phase without elimination.
+     * Validates and clamps to reasonable range (0.0-0.5).
+     */
+    public double getVotingPenaltyPerPhase() {
+        double penalty = config.getDouble("voting.penalty.per-phase", 0.0333);
+        if (penalty < 0.0) {
+            plugin.getLogger().warning("Voting penalty per phase too low (" + penalty + "), using minimum 0.0");
+            return 0.0;
+        }
+        if (penalty > 0.5) {
+            plugin.getLogger().warning("Voting penalty per phase too high (" + penalty + "), using maximum 0.5");
+            return 0.5;
+        }
+        return penalty;
+    }
+    
+    /**
+     * Gets the maximum number of phases that can accumulate penalty.
+     * Validates and clamps to reasonable range (1-10).
+     */
+    public int getVotingMaxPenaltyPhases() {
+        int maxPhases = config.getInt("voting.penalty.max-phases", 3);
+        if (maxPhases < 1) {
+            plugin.getLogger().warning("Voting max penalty phases too low (" + maxPhases + "), using minimum 1");
+            return 1;
+        }
+        if (maxPhases > 10) {
+            plugin.getLogger().warning("Voting max penalty phases too high (" + maxPhases + "), using maximum 10");
+            return 10;
+        }
+        return maxPhases;
+    }
+    
+    /**
+     * Gets the maximum penalty reduction percentage.
+     * Validates and clamps to reasonable range (0.0-0.5).
+     */
+    public double getVotingMaxPenalty() {
+        double maxPenalty = config.getDouble("voting.penalty.max-reduction", 0.10);
+        if (maxPenalty < 0.0) {
+            plugin.getLogger().warning("Voting max penalty too low (" + maxPenalty + "), using minimum 0.0");
+            return 0.0;
+        }
+        if (maxPenalty > 0.5) {
+            plugin.getLogger().warning("Voting max penalty too high (" + maxPenalty + "), using maximum 0.5");
+            return 0.5;
+        }
+        return maxPenalty;
     }
 
     /**

--- a/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
@@ -113,6 +113,11 @@ public class ConfigManager {
         if (!config.contains("voting.penalty.max-reduction")) {
             config.set("voting.penalty.max-reduction", 0.10); // 10% max reduction
         }
+        
+        // Spark ability settings
+        if (!config.contains("spark.secondary-ability")) {
+            config.set("spark.secondary-ability", "random"); // Default: random selection
+        }
 
         // Cosmetic settings
         if (!config.contains("cosmetics.random-skins-enabled")) {
@@ -407,6 +412,24 @@ public class ConfigManager {
             return 0.5;
         }
         return maxPenalty;
+    }
+    
+    /**
+     * Gets the configured Spark secondary ability selection mode.
+     * Returns "random" for random selection, or a specific ability name.
+     * Valid values: "random", "hunter_vision", "spark_swap"
+     */
+    public String getSparkSecondaryAbility() {
+        String ability = config.getString("spark.secondary-ability", "random");
+        if (ability == null) {
+            return "random";
+        }
+        String lowerAbility = ability.toLowerCase().trim();
+        if (lowerAbility.equals("random") || lowerAbility.equals("hunter_vision") || lowerAbility.equals("spark_swap")) {
+            return lowerAbility;
+        }
+        plugin.getLogger().warning("Invalid Spark secondary ability setting: " + ability + ". Valid options: random, hunter_vision, spark_swap. Using default: random");
+        return "random";
     }
 
     /**

--- a/src/main/java/com/ohacd/matchbox/game/cosmetic/SkinManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/cosmetic/SkinManager.java
@@ -52,8 +52,8 @@ public class SkinManager {
     private static final Pattern PROFILE_ID_PATTERN = Pattern.compile("\"id\"\\s*:\\s*\"([0-9a-fA-F]{32})\"");
     // Signed Steve (classic) texture pulled from Mojang session servers.
     private static final SkinData DEFAULT_STEVE = new SkinData(
-        "ewogICJ0aW1lc3RhbXAiIDogMTcwODk5MzE5MzU2OCwKICAicHJvZmlsZUlkIiA6ICI3ZTU5NzY0MjNjNTQ0ZjM2YjRhMGE0ZTViMTA3YzdmOCIsCiAgInByb2ZpbGVOYW1lIiA6ICJDbGFzc2ljU3RldmUiLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzQ1ZjRmYThjNDIwMmY1YTU4NWJiMDIzMmIxYzYzNzU2ZjJiOGY4YzlmYWZiZjM3ZmZiMDZmMTJhM2Y3NTcwOCIKICAgIH0KICB9Cn0=",
-        "TsDcm/o7blZH0Vt9gnXjASK9SKaKdXt/GAbK6n1h5sqkRLVyg0tutlKJIcLxBvS2Ou81bspUkC3DdEaUBPxURFdKXWyYPUzw+k2OibNFeDtDRv28iIgj2w0+q2vYiSkf0YZMNjyvE+mpWCfX/rVxnJjVt6PL1VZLmy5t/8O1EJe4mqDmCA8EJdlE6zV6TxevYrNAvZbtDYMBRi6S+cbRf8N+SvK9sR8z32cb96UVUsShkLT0sejGMfMZXeENPRdyX0tswrMl2BLJ0XkwpMHosSGQIhvrvCrv0D2GBKZFFKEwiafdUgIT71BnF8sxX2UeCzWbHurRosAvGwYNoM4rZq1ReTTSJ+eUqAZuZtq72kPWBzuKOfVphotphA4NRtZ7mT/IKt1IxFkrnYOuh2DYChCVa5p1Q0lS67ZHrnCIsiZTPeMT6OANil4Y1j/8QcuvG+DBtqFPRNEhPVqOgjaRdjumdFZKvgt9gLxBi82p4tAUnGKxhPeB9XFVQ+dGhDffnZllVuvYDGx+fLOJ3Hj7MfKcsRcm0NdOdaGmVQ6FacGWN/+t7Qu0f8ExhlB62iBygg2uQ4CWmUgCaS6zUzmPa9uCt3xBhVG2G+R/wab8bVfcOltwOXSHhtQ8ZRpjYvuTmtzJ1Rtlm1B5dCQzv0XKnKKwjpVrWzq+q0lQjCDY+o2jsf6qi5hbs="
+        "e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDE5MWM0OTRiZjA2ZTYzMjg0YWI5MDdmMDRiNmQ5YTFiNWU2MzlmYTUxNmMzOTQzMTA2ZWEzNmUwMWYwMWJkMCJ9fX0=",
+        "" // No signature for default steve skin
     );
     
 

--- a/src/main/java/com/ohacd/matchbox/game/state/GameState.java
+++ b/src/main/java/com/ohacd/matchbox/game/state/GameState.java
@@ -1,5 +1,6 @@
 package com.ohacd.matchbox.game.state;
 
+import com.ohacd.matchbox.game.ability.SparkSecondaryAbility;
 import com.ohacd.matchbox.game.utils.Role;
 import org.bukkit.entity.Player;
 
@@ -17,9 +18,11 @@ public class GameState {
     private final Set<UUID> beenCuredThisRound = new HashSet<>();
     private final Set<UUID> usedHealingSightThisRound = new HashSet<>();
     private final Set<UUID> usedHunterVisionThisRound = new HashSet<>();
+    private final Set<UUID> usedSparkSwapThisRound = new HashSet<>();
     private final Set<UUID> infectedThisRound = new HashSet<>();
     private final Map<UUID, Long> pendingDeathTime = new HashMap<>();
     private final Set<UUID> allParticipatingPlayers = new HashSet<>();
+    private SparkSecondaryAbility sparkSecondaryAbility = SparkSecondaryAbility.HUNTER_VISION;
     private String activeSessionName = null;
     private int currentRound = 0;
 
@@ -36,6 +39,7 @@ public class GameState {
         infectedThisRound.clear();
         usedHealingSightThisRound.clear();
         usedHunterVisionThisRound.clear();
+        usedSparkSwapThisRound.clear();
         pendingDeathTime.clear();
         allParticipatingPlayers.clear();
         activeSessionName = null;
@@ -54,6 +58,8 @@ public class GameState {
         infectedThisRound.clear();
         usedHealingSightThisRound.clear();
         usedHunterVisionThisRound.clear();
+        usedSparkSwapThisRound.clear();
+        sparkSecondaryAbility = SparkSecondaryAbility.HUNTER_VISION;
     }
 
     /**
@@ -242,6 +248,30 @@ public class GameState {
      */
     public boolean hasUsedHunterVisionThisRound(UUID playerId) {
         return usedHunterVisionThisRound.contains(playerId);
+    }
+
+    /**
+     * Marks that a player has used the Spark Swap ability this round.
+     */
+    public void markUsedSparkSwap(UUID playerId) {
+        usedSparkSwapThisRound.add(playerId);
+    }
+
+    /**
+     * Checks if a player has already used Spark Swap this round.
+     */
+    public boolean hasUsedSparkSwapThisRound(UUID playerId) {
+        return usedSparkSwapThisRound.contains(playerId);
+    }
+
+    public SparkSecondaryAbility getSparkSecondaryAbility() {
+        return sparkSecondaryAbility;
+    }
+
+    public void setSparkSecondaryAbility(SparkSecondaryAbility sparkSecondaryAbility) {
+        if (sparkSecondaryAbility != null) {
+            this.sparkSecondaryAbility = sparkSecondaryAbility;
+        }
     }
 
     /**

--- a/src/main/java/com/ohacd/matchbox/game/vote/DynamicVotingThreshold.java
+++ b/src/main/java/com/ohacd/matchbox/game/vote/DynamicVotingThreshold.java
@@ -1,0 +1,182 @@
+package com.ohacd.matchbox.game.vote;
+
+import com.ohacd.matchbox.game.config.ConfigManager;
+
+/**
+ * Calculates dynamic voting thresholds based on alive player count.
+ * Uses logarithmic scaling between key points:
+ * - 20 players: 20% threshold
+ * - 7 players: 30% threshold
+ * - 3 players and below: 50% threshold
+ */
+public class DynamicVotingThreshold {
+    private final ConfigManager configManager;
+    
+    // Key points for threshold calculation
+    private static final int MAX_PLAYERS = 20;
+    private static final int MID_PLAYERS = 7;
+    private static final int MIN_PLAYERS = 3;
+    
+    // Default threshold percentages (can be overridden by config)
+    private static final double DEFAULT_THRESHOLD_20 = 0.20;  // 20%
+    private static final double DEFAULT_THRESHOLD_7 = 0.30;   // 30%
+    private static final double DEFAULT_THRESHOLD_3 = 0.50;   // 50%
+    
+    // Penalty system defaults
+    private static final double DEFAULT_PENALTY_PER_PHASE = 0.0333; // ~3.33% per phase (10% over 3 phases)
+    private static final int DEFAULT_MAX_PENALTY_PHASES = 3;
+    private static final double DEFAULT_MAX_PENALTY = 0.10; // 10% max penalty
+    
+    public DynamicVotingThreshold(ConfigManager configManager) {
+        this.configManager = configManager;
+    }
+    
+    /**
+     * Calculates the base threshold percentage for a given number of alive players.
+     * Uses logarithmic interpolation between key points.
+     */
+    public double calculateBaseThreshold(int alivePlayerCount) {
+        if (alivePlayerCount < 2) {
+            // Game should end before this, but handle edge case
+            return 1.0; // 100% threshold (impossible)
+        }
+        
+        if (alivePlayerCount > MAX_PLAYERS) {
+            // Cap at max players
+            return getThresholdAt20Players();
+        }
+        
+        // Get config values
+        double threshold20 = getThresholdAt20Players();
+        double threshold7 = getThresholdAt7Players();
+        double threshold3 = getThresholdAt3Players();
+        
+        if (alivePlayerCount <= MIN_PLAYERS) {
+            // 3 players or less: use 50% threshold
+            return threshold3;
+        } else if (alivePlayerCount <= MID_PLAYERS) {
+            // Between 4 and 7 players: logarithmic interpolation between 30% and 50%
+            return logarithmicInterpolation(
+                alivePlayerCount,
+                MIN_PLAYERS, threshold3,
+                MID_PLAYERS, threshold7
+            );
+        } else {
+            // Between 8 and 20 players: logarithmic interpolation between 20% and 30%
+            return logarithmicInterpolation(
+                alivePlayerCount,
+                MID_PLAYERS, threshold7,
+                MAX_PLAYERS, threshold20
+            );
+        }
+    }
+    
+    /**
+     * Calculates the effective threshold after applying penalty for consecutive no-elimination phases.
+     */
+    public double calculateEffectiveThreshold(int alivePlayerCount, int consecutiveNoEliminationPhases) {
+        double baseThreshold = calculateBaseThreshold(alivePlayerCount);
+        
+        if (consecutiveNoEliminationPhases <= 0) {
+            return baseThreshold;
+        }
+        
+        // Calculate penalty
+        double penaltyPerPhase = getPenaltyPerPhase();
+        int maxPenaltyPhases = getMaxPenaltyPhases();
+        double maxPenalty = getMaxPenalty();
+        
+        int effectivePhases = Math.min(consecutiveNoEliminationPhases, maxPenaltyPhases);
+        double penalty = effectivePhases * penaltyPerPhase;
+        
+        // Cap penalty at max
+        penalty = Math.min(penalty, maxPenalty);
+        
+        // Apply penalty (reduce threshold)
+        double effectiveThreshold = baseThreshold - penalty;
+        
+        // Ensure threshold doesn't go below 0 or above 1
+        return Math.max(0.0, Math.min(1.0, effectiveThreshold));
+    }
+    
+    /**
+     * Performs logarithmic interpolation between two points.
+     * Uses natural logarithm for smooth scaling.
+     */
+    private double logarithmicInterpolation(double x, double x1, double y1, double x2, double y2) {
+        if (x <= x1) return y1;
+        if (x >= x2) return y2;
+        
+        // Logarithmic interpolation formula
+        // Using log scale: y = y1 + (y2 - y1) * (log(x) - log(x1)) / (log(x2) - log(x1))
+        double logX = Math.log(x);
+        double logX1 = Math.log(x1);
+        double logX2 = Math.log(x2);
+        
+        if (Math.abs(logX2 - logX1) < 0.0001) {
+            // Avoid division by zero
+            return y1;
+        }
+        
+        double ratio = (logX - logX1) / (logX2 - logX1);
+        return y1 + (y2 - y1) * ratio;
+    }
+    
+    /**
+     * Checks if the vote count meets the threshold for elimination.
+     */
+    public boolean meetsThreshold(int voteCount, int alivePlayerCount, int consecutiveNoEliminationPhases) {
+        if (alivePlayerCount <= 0) {
+            return false;
+        }
+        
+        double threshold = calculateEffectiveThreshold(alivePlayerCount, consecutiveNoEliminationPhases);
+        double requiredVotes = alivePlayerCount * threshold;
+        
+        // Round up to nearest integer (ceiling)
+        int requiredVotesInt = (int) Math.ceil(requiredVotes);
+        
+        return voteCount >= requiredVotesInt;
+    }
+    
+    /**
+     * Gets the minimum vote count required for elimination.
+     */
+    public int getRequiredVoteCount(int alivePlayerCount, int consecutiveNoEliminationPhases) {
+        if (alivePlayerCount <= 0) {
+            return Integer.MAX_VALUE; // Impossible
+        }
+        
+        double threshold = calculateEffectiveThreshold(alivePlayerCount, consecutiveNoEliminationPhases);
+        double requiredVotes = alivePlayerCount * threshold;
+        
+        // Round up to nearest integer (ceiling)
+        return (int) Math.ceil(requiredVotes);
+    }
+    
+    // Config getters with defaults
+    private double getThresholdAt20Players() {
+        return configManager.getVotingThresholdAt20Players();
+    }
+    
+    private double getThresholdAt7Players() {
+        return configManager.getVotingThresholdAt7Players();
+    }
+    
+    private double getThresholdAt3Players() {
+        return configManager.getVotingThresholdAt3Players();
+    }
+    
+    private double getPenaltyPerPhase() {
+        return configManager.getVotingPenaltyPerPhase();
+    }
+    
+    private int getMaxPenaltyPhases() {
+        return configManager.getVotingMaxPenaltyPhases();
+    }
+    
+    private double getMaxPenalty() {
+        return configManager.getVotingMaxPenalty();
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -192,6 +192,25 @@ discussion:
 voting:
   # Voting phase duration in seconds
   duration: 15
+  
+  # Dynamic voting threshold settings
+  # Thresholds are calculated logarithmically between these key points
+  threshold:
+    # Threshold percentage at 20 players (0.20 = 20%)
+    at-20-players: 0.20
+    # Threshold percentage at 7 players (0.30 = 30%)
+    at-7-players: 0.30
+    # Threshold percentage at 3 players and below (0.50 = 50%)
+    at-3-players: 0.50
+  
+  # Penalty system for voting phases without elimination
+  penalty:
+    # Penalty percentage applied per phase without elimination (0.0333 = ~3.33%)
+    per-phase: 0.0333
+    # Maximum number of phases that can accumulate penalty
+    max-phases: 3
+    # Maximum penalty reduction percentage (0.10 = 10%)
+    max-reduction: 0.10
 
 # Cosmetic Settings
 cosmetics:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -188,6 +188,12 @@ discussion:
     # Discussion phase duration in seconds
   duration: 30
 
+# Spark Ability Settings
+spark:
+  # Spark secondary ability selection mode
+  # Options: "random" (default - randomly selects each round), "hunter_vision", "spark_swap"
+  secondary-ability: random
+
 # Voting Phase Settings
 voting:
   # Voting phase duration in seconds


### PR DESCRIPTION
## [0.9.3] - Latest Release (It's the little quirks in life)

### Added
- **Spark Secondary Ability System**: Spark now rolls a secondary ability each round
  - Hunter Vision _or_ Spark Swap, alongside Swipe
  - Spark Swap occupies the Hunter Vision slot (slot 28) when selected
  - Spark Swap teleports with preloaded chunks, preserved velocity, and preserved look direction (designed to be invisible)
- **Dynamic Voting Threshold System**: Voting thresholds now scale dynamically based on alive player count
  - Logarithmic scaling between key points: 20 players (20%), 7 players (30%), 3 players and below (50%)
  - Works for 2-20 players with smooth threshold transitions
  - Threshold display shown during voting phase: "Threshold: X/Y" (required votes / alive players) (Dantizzle)
- **Voting Penalty System**: Penalty applied when voting phases end without elimination
  - Each phase without elimination reduces the threshold by ~3.33% (configurable)
  - Maximum penalty of 10% after 3 consecutive no-elimination phases
  - Penalty resets when a successful elimination occurs
- **Enhanced Tie Handling**: Ties are now checked against the dynamic threshold
  - If tie vote count doesn't meet threshold: no elimination occurs
  - If tie vote count meets threshold: random player from tie is eliminated
- **Voting Configuration**: All voting threshold values are now configurable in `config.yml`
  - `voting.threshold.at-20-players` - Threshold percentage at 20 players (default: 0.20)
  - `voting.threshold.at-7-players` - Threshold percentage at 7 players (default: 0.30)
  - `voting.threshold.at-3-players` - Threshold percentage at 3 players and below (default: 0.50)
  - `voting.penalty.per-phase` - Penalty percentage per phase without elimination (default: 0.0333)
  - `voting.penalty.max-phases` - Maximum phases that accumulate penalty (default: 3)
  - `voting.penalty.max-reduction` - Maximum penalty reduction percentage (default: 0.10)
- **Spark Ability Configuration**: Spark secondary ability selection is now configurable
  - `spark.secondary-ability` - Choose Spark ability: "random" (default), "hunter_vision", or "spark_swap"
  - When set to "random", ability is randomly selected each round (default behavior)
  - When set to a specific ability, that ability is always used

### Changed
- **Ability System Routing**: Ability system routing remains unified; Spark inventories are rebuilt each swipe phase with the chosen secondary
- **Voting Phase Display**: Actionbar now shows both countdown timer and threshold requirement
  - Format: "Voting: Xs | Threshold: Y/Z" (timer and required votes / alive players)
  - Updates every second alongside the countdown timer
- **Voting Phase Instructions**: Improved voting phase start messages
  - Removed counter-intuitive "right-click player while holding paper" instruction
  - Added information that players can choose to not vote
  - Added threshold requirement display in title subtitle
  - Added explanation that no elimination occurs if threshold isn't met
- **Phase Visuals**: Skins are no longer reset to original during discussion/voting, and nametags remain hidden in those phases
  - Players keep their assigned game skins across phases until swipe starts again
  - Nametags stay hidden during discussion and voting (revealed only on elimination)
- **Vote Resolution**: Voting now requires meeting the dynamic threshold instead of simple majority
  - Players see clear feedback when threshold isn't met
  - System tracks consecutive no-elimination phases for penalty calculation
  
### Fixed
- **Steve skin override**: `cosmetics.use-steve-skins` now correctly applies Steve skins to players (Dantizzle)
