### PR TITLE
0.9.4 (Ability system)

### DIFF
--- a/BETA_RECRUITMENT.md
+++ b/BETA_RECRUITMENT.md
@@ -10,7 +10,7 @@ Matchbox is a 7-player social deduction game where players work together to iden
 - **Recording-Proof Design**: Identical inventories, paper-based abilities, hologram chat
 - **Three Roles**: Spark (impostor), Medic (can save players), Innocent (detective)
 - **Three Phases**: Swipe (3 min), Discussion (30 sec), Voting (15 sec)
-- **Special Abilities**: Hunter Vision, Healing Touch, Healing Sight
+- **Special Abilities**: Hunter Vision, Spark Swap, Delusion, Healing Touch, Healing Sight
 - **Full Game Loop**: Multiple rounds until win condition
 
 ## We're Looking For Beta Testers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the Matchbox plugin will be documented in this file.
   - Fake infections appear identical to real infections to the medic (same particles)
   - Medic can see delusion infections using Healing Sight alongside real infections
   - Medic can cure delusion infections, wasting their cure on a non-infected player
-  - Delusion infections automatically decay after 1 minute
+  - Delusion infections automatically decay after 30 seconds
   - Delusion infections do not cause elimination when discussion phase starts
   - Configurable via `spark.secondary-ability` in config.yml
   - Options: "random" (default), "hunter_vision", "spark_swap", "delusion"
@@ -38,6 +38,9 @@ All notable changes to the Matchbox plugin will be documented in this file.
   - All players now consistently receive steve skins when enabled
   - Skins are reapplied at the start of each new round to ensure consistency
   - Fixed issue where some players would get alex or random skins instead of steve
+- **Invalid default seat locations**: Fixed an error where default seatlocations weren't loading correctly when used with the `m4tchb0x` map
+  - Default Spawn/Seat locations are no longer linked to a world folder named `world` 
+  - Now linked to a world folder named `m4tchb0x`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ All notable changes to the Matchbox plugin will be documented in this file.
   - MedicSightListener now checks if ability is active before allowing use
   - System is now extensible for adding new medic abilities in the future
 - **Config steve skin override**: Default config now comes with steve skin override as true by default
-- Random skin toggle is now set to false by default
+  - Random skin toggle is now set to false by default
+- **Debug command**: Fake infected (Delusion infection) is tracked by the debug command
+  - Added the fake infected param to `/matchbox debug` command
 
 ### Fixed
 - **Steve Skin Override**: Fixed inconsistent steve skin application

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,44 @@
 
 All notable changes to the Matchbox plugin will be documented in this file.
 
-## [0.9.3] - Latest Release (The little quirks of life)
+## [0.9.4] - Latest Release (Ability System)
+
+### Added
+- **Medic Secondary Ability System**: Medic now uses the same ability system as Spark
+  - Healing Sight is now tracked as a secondary ability (preparing for future abilities)
+  - System modeled after the Spark secondary ability system for consistency
+  - Configurable via `medic.secondary-ability` in config.yml
+  - Options: "random" (default), "healing_sight"
+  - Ready for future medic abilities to be added
+- **Delusion Ability**: New Spark secondary ability that creates fake infections
+  - Spark can activate an 8-second window, then right-click a player to apply a fake infection
+  - Fake infections appear identical to real infections to the medic (same particles)
+  - Medic can see delusion infections using Healing Sight alongside real infections
+  - Medic can cure delusion infections, wasting their cure on a non-infected player
+  - Delusion infections automatically decay after 1 minute
+  - Delusion infections do not cause elimination when discussion phase starts
+  - Configurable via `spark.secondary-ability` in config.yml
+  - Options: "random" (default), "hunter_vision", "spark_swap", "delusion"
+
+### Changed
+- **Medic Ability System Architecture**: Refactored medic abilities to match Spark's system
+  - Created `MedicSecondaryAbility` enum for ability tracking
+  - Added ability selection logic in GameManager
+  - Updated InventoryManager to handle medic abilities dynamically
+  - MedicSightListener now checks if ability is active before allowing use
+  - System is now extensible for adding new medic abilities in the future
+- **Config steve skin override**: Default config now comes with steve skin override as true by default
+- Random skin toggle is now set to false by default
+
+### Fixed
+- **Steve Skin Override**: Fixed inconsistent steve skin application
+  - All players now consistently receive steve skins when enabled
+  - Skins are reapplied at the start of each new round to ensure consistency
+  - Fixed issue where some players would get alex or random skins instead of steve
+
+---
+
+## [0.9.3] - (The little quirks of life)
 
 ### Added
 - **Spark Secondary Ability System**: Spark now rolls a secondary ability each round

--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ discussion:
 - Random skins toggle (`cosmetics.random-skins-enabled`)
 - Steve skins option (`cosmetics.use-steve-skins`) - Use default Steve skin for all players
 - **Spark Ability Selection**:
-  - `spark.secondary-ability` - Choose Spark secondary ability: "random" (default), "hunter_vision", or "spark_swap"
+  - `spark.secondary-ability` - Choose Spark secondary ability: "random" (default), "hunter_vision", "spark_swap", or "delusion"
   - "random" - Randomly selects ability each round (default behavior)
   - "hunter_vision" - Always uses Hunter Vision ability
   - "spark_swap" - Always uses Spark Swap ability
+  - "delusion" - Always uses Delusion ability
 - **Dynamic Voting Thresholds**:
   - `voting.threshold.at-20-players` - Threshold at 20 players (default: 0.20 = 20%)
   - `voting.threshold.at-7-players` - Threshold at 7 players (default: 0.30 = 30%)
@@ -145,7 +146,10 @@ discussion:
 **Spark (Impostor)**
 - Eliminate all players without being caught
 - Infect one player per round
- - Each round, you roll one secondary ability: Hunter Vision **or** Spark Swap (invisible teleport swap that preserves velocity and look direction)
+- Each round, you roll one secondary ability:
+  - **Hunter Vision**: See all players with particles for 15 seconds
+  - **Spark Swap**: Invisible teleport swap with a random player (preserves velocity and look direction)
+  - **Delusion**: Apply a fake infection to a player that medic can see but doesn't cause elimination (decays after 1 minute)
 
 **Medic**
 - Identify Spark and save infected players
@@ -182,7 +186,7 @@ Players will also see a welcome message when joining the server with information
 
 ---
 
-**Version**: 0.9.3  
+**Version**: 0.9.4  
 **Minecraft API**: 1.21.10  
 **License**: MIT  
 **Developer**: OhACD

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.ohacd'
-version = '0.9.3'
+version = '0.9.4'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -38,7 +38,7 @@ import java.util.Set;
  */
 public final class Matchbox extends JavaPlugin {
     // Project status, versioning and update name
-    private static final ProjectStatus projectStatus = ProjectStatus.DEVELOPMENT; // Main toggle for project status
+    private static final ProjectStatus projectStatus = ProjectStatus.STABLE; // Main toggle for project status
     private String updateName = "Ability System";
     private String currentVersion;
     private CheckProjectVersion versionChecker;

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -39,7 +39,7 @@ import java.util.Set;
 public final class Matchbox extends JavaPlugin {
     // Project status, versioning and update name
     private static final ProjectStatus projectStatus = ProjectStatus.DEVELOPMENT; // Main toggle for project status
-    private String updateName = "Ability System (no cool names this time)";
+    private String updateName = "Ability System";
     private String currentVersion;
     private CheckProjectVersion versionChecker;
 

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -10,6 +10,8 @@ import com.ohacd.matchbox.game.ability.AbilityManager;
 import com.ohacd.matchbox.game.ability.MedicAbilityListener;
 import com.ohacd.matchbox.game.ability.MedicHitListener;
 import com.ohacd.matchbox.game.ability.MedicSightListener;
+import com.ohacd.matchbox.game.ability.DelusionActivationListener;
+import com.ohacd.matchbox.game.ability.DelusionHitListener;
 import com.ohacd.matchbox.game.ability.SparkSwapAbility;
 import com.ohacd.matchbox.game.ability.SparkVisionListener;
 import com.ohacd.matchbox.game.ability.SwipeActivationListener;
@@ -36,8 +38,8 @@ import java.util.Set;
  */
 public final class Matchbox extends JavaPlugin {
     // Project status, versioning and update name
-    private static final ProjectStatus projectStatus = ProjectStatus.STABLE; // Main toggle for project status
-    private String updateName = "It's the little quirks in life";
+    private static final ProjectStatus projectStatus = ProjectStatus.DEVELOPMENT; // Main toggle for project status
+    private String updateName = "Ability System (no cool names this time)";
     private String currentVersion;
     private CheckProjectVersion versionChecker;
 
@@ -73,6 +75,8 @@ public final class Matchbox extends JavaPlugin {
         abilityManager.registerAbility(new MedicHitListener(gameManager));
         abilityManager.registerAbility(new MedicSightListener(gameManager));
         abilityManager.registerAbility(new SparkSwapAbility(this));
+        abilityManager.registerAbility(new DelusionActivationListener(gameManager, this));
+        abilityManager.registerAbility(new DelusionHitListener(gameManager));
         getServer().getPluginManager().registerEvents(new AbilityEventListener(abilityManager), this);
 
         // Register voting listeners

--- a/src/main/java/com/ohacd/matchbox/game/GameManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/GameManager.java
@@ -639,6 +639,25 @@ public class GameManager {
     }
 
     /**
+     * Restores the secondary ability paper (Slot 28) for Sparks/Medics when a window expires unused.
+     * @param player
+     */
+    public void restoreSecondaryAbilityPaper(Player player) {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+        UUID id = player.getUniqueId();
+        SessionGameContext context = getContextForPlayer(id);
+        if (context == null) {
+            return;
+        }
+        Role role = context.getGameState().getRole(id);
+        if (role == Role.SPARK || role == Role.MEDIC) {
+            inventoryManager.refreshSecondaryAbilityPaper(player, role, context);
+        }
+    }
+
+    /**
      * Activates Healing Sight for the medic.
      * Shows highlight particles on all infected players for 15 seconds (only visible to medic).
      * This is separate from the cure ability.

--- a/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
+++ b/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
@@ -33,6 +33,9 @@ public class SessionGameContext {
     /** Maps player UUID to expiry timestamp for active cure windows */
     private final Map<UUID, Long> activeCureWindow = new ConcurrentHashMap<>();
     
+    /** Maps player UUID to expiry timestamp for active delusion windows */
+    private final Map<UUID, Long> activeDelusionWindow = new ConcurrentHashMap<>();
+    
     /** Discussion location for the current round */
     private Location currentDiscussionLocation;
     
@@ -86,6 +89,10 @@ public class SessionGameContext {
         return activeCureWindow;
     }
     
+    public Map<UUID, Long> getActiveDelusionWindow() {
+        return activeDelusionWindow;
+    }
+    
     public Location getCurrentDiscussionLocation() {
         return currentDiscussionLocation;
     }
@@ -131,6 +138,7 @@ public class SessionGameContext {
     public void cleanup() {
         activeSwipeWindow.clear();
         activeCureWindow.clear();
+        activeDelusionWindow.clear();
         currentDiscussionLocation = null;
         currentSpawnLocations = null;
         consecutiveNoEliminationPhases = 0;

--- a/src/main/java/com/ohacd/matchbox/game/ability/DelusionActivationListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/DelusionActivationListener.java
@@ -12,18 +12,22 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
 
 /**
- * Activates Healing Sight when a Medic clicks a PAPER in slot 28 (above hotbar slot 1).
+ * Activates an 8s delusion window when a Spark clicks a PAPER in slot 28 (above hotbar slot 1).
  * Supports right-click and left-click in inventory, and right-click when held in main hand.
- * Shows subtle highlight particles on all infected players for 15 seconds (only visible to medic).
  * Silent by design (no messages/holograms).
  */
-public class MedicSightListener implements AbilityHandler {
+public class DelusionActivationListener implements AbilityHandler {
     private final GameManager gameManager;
+    private final Plugin plugin;
 
-    public MedicSightListener(GameManager gameManager) {
+    public DelusionActivationListener(GameManager gameManager, Plugin plugin) {
         this.gameManager = gameManager;
+        this.plugin = plugin;
     }
 
     @Override
@@ -32,7 +36,7 @@ public class MedicSightListener implements AbilityHandler {
         
         Player player = (Player) event.getWhoClicked();
         
-        // Check if clicking the sight paper slot
+        // Check if clicking the delusion paper slot
         int slot = event.getSlot();
         int rawSlot = event.getRawSlot();
         
@@ -48,15 +52,15 @@ public class MedicSightListener implements AbilityHandler {
         ItemStack clicked = event.getCurrentItem();
         if (clicked == null || clicked.getType() != Material.PAPER) return;
         if (!context.getPhaseManager().isPhase(GamePhase.SWIPE)) return;
-        if (context.getGameState().getRole(player.getUniqueId()) != Role.MEDIC) return;
+        if (context.getGameState().getRole(player.getUniqueId()) != Role.SPARK) return;
         
-        // Check if healing sight ability is active for this round
-        if (context.getGameState().getMedicSecondaryAbility() != MedicSecondaryAbility.HEALING_SIGHT) {
+        // Check if delusion ability is active for this round
+        if (context.getGameState().getSparkSecondaryAbility() != SparkSecondaryAbility.DELUSION) {
             return;
         }
 
-        // Check if medic already used healing sight this round
-        if (context.getGameState().hasUsedHealingSightThisRound(player.getUniqueId())) {
+        // Check if spark already used delusion this round
+        if (context.getGameState().hasUsedDelusionThisRound(player.getUniqueId())) {
             return; // Silent - already used this round
         }
 
@@ -71,13 +75,35 @@ public class MedicSightListener implements AbilityHandler {
         // Consume the click (prevent moving the paper)
         event.setCancelled(true);
 
-        // Activate healing sight (shows particles on infected players for 15 seconds)
-        gameManager.activateHealingSight(player);
-        
+        // Start the 8 second delusion window silently
+        Long windowExpiry = gameManager.startDelusionWindow(player, 8);
+        if (windowExpiry == null) {
+            return;
+        }
+
         // Replace paper with gray dye indicator
         ItemStack usedIndicator = InventoryManager.createUsedIndicator(clicked);
         player.getInventory().setItem(slot, usedIndicator);
         player.updateInventory();
+
+        // schedule cleanup that restores the paper if unused
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!player.isOnline()) {
+                    return;
+                }
+                SessionGameContext ctx = gameManager.getContextForPlayer(player.getUniqueId());
+                if (ctx == null) {
+                    return;
+                }
+                Long currentExpiry = ctx.getActiveDelusionWindow().get(player.getUniqueId());
+                if (currentExpiry != null && currentExpiry.equals(windowExpiry)) {
+                    gameManager.endDelusionWindow(player.getUniqueId());
+                    gameManager.restoreAbilityPaper(player);
+                }
+            }
+        }.runTaskLater(plugin, 20L * 8); // 8 seconds
     }
     
     @Override
@@ -95,7 +121,7 @@ public class MedicSightListener implements AbilityHandler {
             return;
         }
         
-        // Check if it's the sight paper by checking slot 28
+        // Check if it's the delusion paper by checking slot 28
         ItemStack slot28Item = player.getInventory().getItem(InventoryManager.getVisionSightPaperSlot());
         if (slot28Item == null || slot28Item.getType() != Material.PAPER || !slot28Item.equals(heldItem)) {
             return;
@@ -104,30 +130,52 @@ public class MedicSightListener implements AbilityHandler {
         if (!context.getPhaseManager().isPhase(GamePhase.SWIPE)) {
             return;
         }
-        if (context.getGameState().getRole(player.getUniqueId()) != Role.MEDIC) {
+        if (context.getGameState().getRole(player.getUniqueId()) != Role.SPARK) {
             return;
         }
         
-        // Check if healing sight ability is active for this round
-        if (context.getGameState().getMedicSecondaryAbility() != MedicSecondaryAbility.HEALING_SIGHT) {
+        // Check if delusion ability is active for this round
+        if (context.getGameState().getSparkSecondaryAbility() != SparkSecondaryAbility.DELUSION) {
             return;
         }
         
-        // Check if medic already used healing sight this round
-        if (context.getGameState().hasUsedHealingSightThisRound(player.getUniqueId())) {
+        // Check if spark already used delusion this round
+        if (context.getGameState().hasUsedDelusionThisRound(player.getUniqueId())) {
             return; // Silent - already used this round
         }
         
         // Prevent interaction
         event.setCancelled(true);
         
-        // Activate healing sight (shows particles on infected players for 15 seconds)
-        gameManager.activateHealingSight(player);
+        // Start the 8 second delusion window silently
+        Long windowExpiry = gameManager.startDelusionWindow(player, 8);
+        if (windowExpiry == null) {
+            return;
+        }
         
         // Replace paper with gray dye indicator in slot 28
         ItemStack usedIndicator = InventoryManager.createUsedIndicator(heldItem);
         player.getInventory().setItem(InventoryManager.getVisionSightPaperSlot(), usedIndicator);
         player.updateInventory();
+
+        // schedule cleanup that restores the paper if unused
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!player.isOnline()) {
+                    return;
+                }
+                SessionGameContext ctx = gameManager.getContextForPlayer(player.getUniqueId());
+                if (ctx == null) {
+                    return;
+                }
+                Long currentExpiry = ctx.getActiveDelusionWindow().get(player.getUniqueId());
+                if (currentExpiry != null && currentExpiry.equals(windowExpiry)) {
+                    gameManager.endDelusionWindow(player.getUniqueId());
+                    gameManager.restoreAbilityPaper(player);
+                }
+            }
+        }.runTaskLater(plugin, 20L * 8); // 8 seconds
     }
 }
 

--- a/src/main/java/com/ohacd/matchbox/game/ability/DelusionActivationListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/DelusionActivationListener.java
@@ -100,7 +100,7 @@ public class DelusionActivationListener implements AbilityHandler {
                 Long currentExpiry = ctx.getActiveDelusionWindow().get(player.getUniqueId());
                 if (currentExpiry != null && currentExpiry.equals(windowExpiry)) {
                     gameManager.endDelusionWindow(player.getUniqueId());
-                    gameManager.restoreAbilityPaper(player);
+                    gameManager.restoreSecondaryAbilityPaper(player);
                 }
             }
         }.runTaskLater(plugin, 20L * 8); // 8 seconds
@@ -172,7 +172,7 @@ public class DelusionActivationListener implements AbilityHandler {
                 Long currentExpiry = ctx.getActiveDelusionWindow().get(player.getUniqueId());
                 if (currentExpiry != null && currentExpiry.equals(windowExpiry)) {
                     gameManager.endDelusionWindow(player.getUniqueId());
-                    gameManager.restoreAbilityPaper(player);
+                    gameManager.restoreSecondaryAbilityPaper(player);
                 }
             }
         }.runTaskLater(plugin, 20L * 8); // 8 seconds

--- a/src/main/java/com/ohacd/matchbox/game/ability/DelusionHitListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/DelusionHitListener.java
@@ -1,0 +1,39 @@
+package com.ohacd.matchbox.game.ability;
+
+import com.ohacd.matchbox.game.GameManager;
+import com.ohacd.matchbox.game.SessionGameContext;
+import com.ohacd.matchbox.game.utils.GamePhase;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+
+/**
+ * Detects right-clicks on other players and forwards to GameManager.handleDelusion()
+ * only when the spark's delusion window is active. Silent; no feedback shown.
+ */
+public class DelusionHitListener implements AbilityHandler {
+    private final GameManager gameManager;
+
+    public DelusionHitListener(GameManager gameManager) {
+        this.gameManager = gameManager;
+    }
+
+    @Override
+    public void handlePlayerInteractEntity(PlayerInteractEntityEvent event, SessionGameContext context) {
+        if (!(event.getRightClicked() instanceof Player)) return;
+        Player attacker = event.getPlayer();
+        Player target = (Player) event.getRightClicked();
+
+        // Only allow during swipe phase
+        if (!context.getPhaseManager().isPhase(GamePhase.SWIPE)) return;
+
+        // Only process if attacker has an active delusion window
+        if (!gameManager.isDelusionWindowActive(attacker.getUniqueId())) return;
+
+        // Delegate to GameManager; it will enforce Spark role and one delusion per round
+        gameManager.handleDelusion(attacker, target);
+
+        // prevent any other interaction side-effects
+        event.setCancelled(true);
+    }
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/ability/MedicSecondaryAbility.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/MedicSecondaryAbility.java
@@ -1,0 +1,9 @@
+package com.ohacd.matchbox.game.ability;
+
+/**
+ * Tracks which secondary Medic ability is active for the current round.
+ */
+public enum MedicSecondaryAbility {
+    HEALING_SIGHT
+}
+

--- a/src/main/java/com/ohacd/matchbox/game/ability/SparkSecondaryAbility.java
+++ b/src/main/java/com/ohacd/matchbox/game/ability/SparkSecondaryAbility.java
@@ -5,6 +5,7 @@ package com.ohacd.matchbox.game.ability;
  */
 public enum SparkSecondaryAbility {
     HUNTER_VISION,
-    SPARK_SWAP
+    SPARK_SWAP,
+    DELUSION
 }
 

--- a/src/main/java/com/ohacd/matchbox/game/action/PlayerActionHandler.java
+++ b/src/main/java/com/ohacd/matchbox/game/action/PlayerActionHandler.java
@@ -7,8 +7,11 @@ import com.ohacd.matchbox.game.utils.GamePhase;
 import com.ohacd.matchbox.game.utils.ParticleUtils;
 import com.ohacd.matchbox.game.utils.Role;
 import com.ohacd.matchbox.game.vote.VoteManager;
+
+import org.bukkit.Color;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Map;
 import java.util.UUID;
@@ -278,7 +281,7 @@ public class PlayerActionHandler {
         // Show subtle lime particles (same as real infection to fool medic)
         ParticleUtils.showColoredParticlesToEveryone(
             target,
-            org.bukkit.Color.fromRGB(50, 205, 50), // Lime green
+            Color.fromRGB(50, 205, 50), // Lime green
             8,
             plugin
         );
@@ -290,7 +293,7 @@ public class PlayerActionHandler {
         final UUID targetIdFinal = targetId;
         final String sessionName = context.getSessionName();
         final SessionGameContext contextFinal = context;
-        org.bukkit.scheduler.BukkitRunnable decayTask = new org.bukkit.scheduler.BukkitRunnable() {
+        BukkitRunnable decayTask = new BukkitRunnable() {
             @Override
             public void run() {
                 // Check if game is still active and player still has delusion infection
@@ -300,13 +303,13 @@ public class PlayerActionHandler {
                 
                 GameState state = contextFinal.getGameState();
                 if (state.isDelusionInfected(targetIdFinal)) {
-                    // Remove delusion infection after 1 minute
+                    // Remove delusion infection after 30 seconds
                     state.removeDelusionInfection(targetIdFinal);
                     plugin.getLogger().info("Delusion infection decayed for player " + targetIdFinal + " in session '" + sessionName + "'");
                 }
             }
         };
-        decayTask.runTaskLater(plugin, 20L * 60); // 60 seconds = 1200 ticks
+        decayTask.runTaskLater(plugin, 20L * 30); // 30 seconds = 600 ticks
         
         plugin.getLogger().info("Delusion registered in session '" + context.getSessionName() + "': " + spark.getName() + " applied delusion to " + target.getName() + " (will decay in 1 minute)");
     }

--- a/src/main/java/com/ohacd/matchbox/game/action/PlayerActionHandler.java
+++ b/src/main/java/com/ohacd/matchbox/game/action/PlayerActionHandler.java
@@ -119,17 +119,29 @@ public class PlayerActionHandler {
             return;
         }
         
-        // Check if target has a pending death to cure
-        if (!gameState.hasPendingDeath(targetId)) {
+        // Check if target has a pending death OR delusion infection to cure
+        boolean hasRealInfection = gameState.hasPendingDeath(targetId);
+        boolean hasDelusionInfection = gameState.isDelusionInfected(targetId);
+        
+        if (!hasRealInfection && !hasDelusionInfection) {
             activeCureWindow.remove(medicId);
             return;
         }
         
         // Mark as cured
         gameState.markCured(medicId);
-        gameState.removePendingDeath(targetId);
-        // NEW: 0.8.7 - mark the target as been cured
-        gameState.markBeenCured(targetId);
+        
+        // Remove real infection if present
+        if (hasRealInfection) {
+            gameState.removePendingDeath(targetId);
+            // NEW: 0.8.7 - mark the target as been cured
+            gameState.markBeenCured(targetId);
+        }
+        
+        // Remove delusion infection if present (wastes the cure)
+        if (hasDelusionInfection) {
+            gameState.removeDelusionInfection(targetId);
+        }
         
         // Show subtle blue particles
         ParticleUtils.showColoredParticlesToEveryone(
@@ -212,6 +224,103 @@ public class PlayerActionHandler {
         if (expiry == null) return false;
         if (expiry <= System.currentTimeMillis()) {
             activeCureWindow.remove(playerId);
+            return false;
+        }
+        return true;
+    }
+    
+    /**
+     * Handles a delusion action from a spark.
+     * Applies a fake infection that medic can see but doesn't cause elimination.
+     */
+    public void handleDelusion(SessionGameContext context, Player spark, Player target) {
+        if (context == null || spark == null || target == null) return;
+        
+        GameState gameState = context.getGameState();
+        
+        // Game must be active
+        if (!gameState.isGameActive()) return;
+        
+        // Both players must be in the same session
+        if (!gameState.getAllParticipatingPlayerIds().contains(target.getUniqueId())) {
+            return;
+        }
+        
+        PhaseManager phaseManager = context.getPhaseManager();
+        Map<UUID, Long> activeDelusionWindow = context.getActiveDelusionWindow();
+        
+        // Phase and permission checks
+        if (!phaseManager.isPhase(GamePhase.SWIPE)) return;
+        
+        UUID sparkId = spark.getUniqueId();
+        UUID targetId = target.getUniqueId();
+        
+        // Only a Spark can use delusion
+        if (gameState.getRole(sparkId) != Role.SPARK) {
+            return;
+        }
+        
+        // Must have an active delusion window
+        if (!isDelusionWindowActive(context, sparkId)) {
+            return;
+        }
+        
+        // If target already has delusion infection, ignore duplicate
+        if (gameState.isDelusionInfected(targetId)) {
+            activeDelusionWindow.remove(sparkId);
+            return;
+        }
+        
+        // Mark as used and apply delusion infection
+        gameState.markUsedDelusion(sparkId);
+        gameState.markDelusionInfected(targetId);
+        
+        // Show subtle lime particles (same as real infection to fool medic)
+        ParticleUtils.showColoredParticlesToEveryone(
+            target,
+            org.bukkit.Color.fromRGB(50, 205, 50), // Lime green
+            8,
+            plugin
+        );
+        
+        // Close the delusion window
+        activeDelusionWindow.remove(sparkId);
+        
+        // Schedule decay after 1 minute (60 seconds)
+        final UUID targetIdFinal = targetId;
+        final String sessionName = context.getSessionName();
+        final SessionGameContext contextFinal = context;
+        org.bukkit.scheduler.BukkitRunnable decayTask = new org.bukkit.scheduler.BukkitRunnable() {
+            @Override
+            public void run() {
+                // Check if game is still active and player still has delusion infection
+                if (contextFinal == null || !contextFinal.getGameState().isGameActive()) {
+                    return;
+                }
+                
+                GameState state = contextFinal.getGameState();
+                if (state.isDelusionInfected(targetIdFinal)) {
+                    // Remove delusion infection after 1 minute
+                    state.removeDelusionInfection(targetIdFinal);
+                    plugin.getLogger().info("Delusion infection decayed for player " + targetIdFinal + " in session '" + sessionName + "'");
+                }
+            }
+        };
+        decayTask.runTaskLater(plugin, 20L * 60); // 60 seconds = 1200 ticks
+        
+        plugin.getLogger().info("Delusion registered in session '" + context.getSessionName() + "': " + spark.getName() + " applied delusion to " + target.getName() + " (will decay in 1 minute)");
+    }
+    
+    /**
+     * Checks if a player has an active delusion window.
+     */
+    public boolean isDelusionWindowActive(SessionGameContext context, UUID playerId) {
+        if (context == null) return false;
+        Map<UUID, Long> activeDelusionWindow = context.getActiveDelusionWindow();
+        Long expiry = activeDelusionWindow.get(playerId);
+        if (expiry == null) return false;
+        if (expiry <= System.currentTimeMillis()) {
+            activeDelusionWindow.remove(playerId);
             return false;
         }
         return true;

--- a/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
@@ -118,13 +118,18 @@ public class ConfigManager {
         if (!config.contains("spark.secondary-ability")) {
             config.set("spark.secondary-ability", "random"); // Default: random selection
         }
+        
+        // Medic ability settings
+        if (!config.contains("medic.secondary-ability")) {
+            config.set("medic.secondary-ability", "random"); // Default: random selection
+        }
 
         // Cosmetic settings
         if (!config.contains("cosmetics.random-skins-enabled")) {
-            config.set("cosmetics.random-skins-enabled", true);
+            config.set("cosmetics.random-skins-enabled", false);
         }
         if (!config.contains("cosmetics.use-steve-skins")) {
-            config.set("cosmetics.use-steve-skins", false);
+            config.set("cosmetics.use-steve-skins", true);
         }
     }
 
@@ -425,10 +430,28 @@ public class ConfigManager {
             return "random";
         }
         String lowerAbility = ability.toLowerCase().trim();
-        if (lowerAbility.equals("random") || lowerAbility.equals("hunter_vision") || lowerAbility.equals("spark_swap")) {
+        if (lowerAbility.equals("random") || lowerAbility.equals("hunter_vision") || lowerAbility.equals("spark_swap") || lowerAbility.equals("delusion")) {
             return lowerAbility;
         }
-        plugin.getLogger().warning("Invalid Spark secondary ability setting: " + ability + ". Valid options: random, hunter_vision, spark_swap. Using default: random");
+        plugin.getLogger().warning("Invalid Spark secondary ability setting: " + ability + ". Valid options: random, hunter_vision, spark_swap, delusion. Using default: random");
+        return "random";
+    }
+    
+    /**
+     * Gets the configured Medic secondary ability selection mode.
+     * Returns "random" for random selection, or a specific ability name.
+     * Valid values: "random", "healing_sight"
+     */
+    public String getMedicSecondaryAbility() {
+        String ability = config.getString("medic.secondary-ability", "random");
+        if (ability == null) {
+            return "random";
+        }
+        String lowerAbility = ability.toLowerCase().trim();
+        if (lowerAbility.equals("random") || lowerAbility.equals("healing_sight")) {
+            return lowerAbility;
+        }
+        plugin.getLogger().warning("Invalid Medic secondary ability setting: " + ability + ". Valid options: random, healing_sight. Using default: random");
         return "random";
     }
 

--- a/src/main/java/com/ohacd/matchbox/game/state/GameState.java
+++ b/src/main/java/com/ohacd/matchbox/game/state/GameState.java
@@ -1,5 +1,6 @@
 package com.ohacd.matchbox.game.state;
 
+import com.ohacd.matchbox.game.ability.MedicSecondaryAbility;
 import com.ohacd.matchbox.game.ability.SparkSecondaryAbility;
 import com.ohacd.matchbox.game.utils.Role;
 import org.bukkit.entity.Player;
@@ -19,10 +20,13 @@ public class GameState {
     private final Set<UUID> usedHealingSightThisRound = new HashSet<>();
     private final Set<UUID> usedHunterVisionThisRound = new HashSet<>();
     private final Set<UUID> usedSparkSwapThisRound = new HashSet<>();
+    private final Set<UUID> usedDelusionThisRound = new HashSet<>();
     private final Set<UUID> infectedThisRound = new HashSet<>();
+    private final Set<UUID> delusionInfectedThisRound = new HashSet<>();
     private final Map<UUID, Long> pendingDeathTime = new HashMap<>();
     private final Set<UUID> allParticipatingPlayers = new HashSet<>();
     private SparkSecondaryAbility sparkSecondaryAbility = SparkSecondaryAbility.HUNTER_VISION;
+    private MedicSecondaryAbility medicSecondaryAbility = MedicSecondaryAbility.HEALING_SIGHT;
     private String activeSessionName = null;
     private int currentRound = 0;
 
@@ -40,6 +44,8 @@ public class GameState {
         usedHealingSightThisRound.clear();
         usedHunterVisionThisRound.clear();
         usedSparkSwapThisRound.clear();
+        usedDelusionThisRound.clear();
+        delusionInfectedThisRound.clear();
         pendingDeathTime.clear();
         allParticipatingPlayers.clear();
         activeSessionName = null;
@@ -59,7 +65,10 @@ public class GameState {
         usedHealingSightThisRound.clear();
         usedHunterVisionThisRound.clear();
         usedSparkSwapThisRound.clear();
+        usedDelusionThisRound.clear();
+        delusionInfectedThisRound.clear();
         sparkSecondaryAbility = SparkSecondaryAbility.HUNTER_VISION;
+        medicSecondaryAbility = MedicSecondaryAbility.HEALING_SIGHT;
     }
 
     /**
@@ -264,6 +273,41 @@ public class GameState {
         return usedSparkSwapThisRound.contains(playerId);
     }
 
+    /**
+     * Marks that a player has used the Delusion ability this round.
+     */
+    public void markUsedDelusion(UUID playerId) {
+        usedDelusionThisRound.add(playerId);
+    }
+
+    /**
+     * Checks if a player has already used Delusion this round.
+     */
+    public boolean hasUsedDelusionThisRound(UUID playerId) {
+        return usedDelusionThisRound.contains(playerId);
+    }
+
+    /**
+     * Marks that a player was infected with delusion (fake infection) this round.
+     */
+    public void markDelusionInfected(UUID playerId) {
+        delusionInfectedThisRound.add(playerId);
+    }
+
+    /**
+     * Checks if a player was infected with delusion this round.
+     */
+    public boolean isDelusionInfected(UUID playerId) {
+        return delusionInfectedThisRound.contains(playerId);
+    }
+
+    /**
+     * Removes delusion infection from a player (when cured).
+     */
+    public void removeDelusionInfection(UUID playerId) {
+        delusionInfectedThisRound.remove(playerId);
+    }
+
     public SparkSecondaryAbility getSparkSecondaryAbility() {
         return sparkSecondaryAbility;
     }
@@ -271,6 +315,16 @@ public class GameState {
     public void setSparkSecondaryAbility(SparkSecondaryAbility sparkSecondaryAbility) {
         if (sparkSecondaryAbility != null) {
             this.sparkSecondaryAbility = sparkSecondaryAbility;
+        }
+    }
+
+    public MedicSecondaryAbility getMedicSecondaryAbility() {
+        return medicSecondaryAbility;
+    }
+
+    public void setMedicSecondaryAbility(MedicSecondaryAbility medicSecondaryAbility) {
+        if (medicSecondaryAbility != null) {
+            this.medicSecondaryAbility = medicSecondaryAbility;
         }
     }
 

--- a/src/main/java/com/ohacd/matchbox/game/state/GameState.java
+++ b/src/main/java/com/ohacd/matchbox/game/state/GameState.java
@@ -466,7 +466,7 @@ public class GameState {
      */
     public String getDebugInfo() {
         return String.format(
-                "GameState[Round=%d, Session=%s, Participating=%d, Alive=%d, Roles=%d, Swiped=%d, Cured=%d, Infected=%d, Pending=%d, beenCured=%d]",
+                "GameState[Round=%d, Session=%s, Participating=%d, Alive=%d, Roles=%d, Swiped=%d, Cured=%d, Infected=%d, Fake-Infected=%d, Pending=%d, beenCured=%d]",
                 currentRound,
                 activeSessionName != null ? activeSessionName : "none",
                 allParticipatingPlayers.size(),
@@ -475,6 +475,7 @@ public class GameState {
                 swipedThisRound.size(),
                 curedThisRound.size(),
                 infectedThisRound.size(),
+                delusionInfectedThisRound.size(),
                 pendingDeathTime.size(),
                 beenCuredThisRound.size()
         );

--- a/src/main/java/com/ohacd/matchbox/game/utils/Managers/InventoryManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/Managers/InventoryManager.java
@@ -661,7 +661,7 @@ public class InventoryManager {
         List<String> lore = new ArrayList<>();
         lore.add("§7Right-click to activate an 8s window.");
         lore.add("§7Then right-click a player to apply");
-        lore.add("§7a fake infection that medic can see.");
+        lore.add("§7a fake infection that the medic can see.");
         lore.add("§7Decays after 1 minute.");
         lore.add("§7Once per round.");
 

--- a/src/main/java/com/ohacd/matchbox/game/utils/Managers/InventoryManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/Managers/InventoryManager.java
@@ -11,6 +11,7 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.Plugin;
 
+import com.ohacd.matchbox.game.ability.MedicSecondaryAbility;
 import com.ohacd.matchbox.game.ability.SparkSecondaryAbility;
 import com.ohacd.matchbox.game.utils.PlayerNameUtils;
 import com.ohacd.matchbox.game.utils.Role;
@@ -59,7 +60,7 @@ public class InventoryManager {
      * Sets up the game inventory for a player based on their role.
      * All players get identical layouts with role-specific papers.
      */
-    public void setupPlayerInventory(Player player, Role role, SparkSecondaryAbility sparkAbility) {
+    public void setupPlayerInventory(Player player, Role role, SparkSecondaryAbility sparkAbility, MedicSecondaryAbility medicAbility) {
         if (player == null || !player.isOnline()) {
             plugin.getLogger().warning("Cannot setup inventory for null or offline player");
             return;
@@ -90,18 +91,26 @@ public class InventoryManager {
                 ItemStack swipePaper = createSwipePaper();
                 ItemStack visionPaper = createHunterVisionPaper();
                 ItemStack swapPaper = createSparkSwapPaper();
+                ItemStack delusionPaper = createDelusionPaper();
                 inv.setItem(SWIPE_CURE_PAPER_SLOT, swipePaper);
                 if (sparkAbility == SparkSecondaryAbility.SPARK_SWAP) {
                     inv.setItem(VISION_SIGHT_PAPER_SLOT, swapPaper);
+                } else if (sparkAbility == SparkSecondaryAbility.DELUSION) {
+                    inv.setItem(VISION_SIGHT_PAPER_SLOT, delusionPaper);
                 } else {
                     inv.setItem(VISION_SIGHT_PAPER_SLOT, visionPaper);
                 }
             } else if (role == Role.MEDIC) {
-                // Medic: Healing Touch in slot 27, Healing Sight in slot 28
+                // Medic: Healing Touch in slot 27, secondary ability in slot 28
                 ItemStack curePaper = createHealingTouchPaper();
                 ItemStack sightPaper = createHealingSightPaper();
                 inv.setItem(SWIPE_CURE_PAPER_SLOT, curePaper);
-                inv.setItem(VISION_SIGHT_PAPER_SLOT, sightPaper);
+                if (medicAbility == MedicSecondaryAbility.HEALING_SIGHT) {
+                    inv.setItem(VISION_SIGHT_PAPER_SLOT, sightPaper);
+                } else {
+                    // Default to healing sight if unknown ability
+                    inv.setItem(VISION_SIGHT_PAPER_SLOT, sightPaper);
+                }
             } else {
                 // Innocent: Empty slots (or placeholder papers if needed)
                 // For now, leave empty for innocents
@@ -161,7 +170,7 @@ public class InventoryManager {
     /**
      * Sets up inventories for all players in a collection.
      */
-    public void setupInventories(Collection<Player> players, Map<UUID, Role> roles, SparkSecondaryAbility sparkAbility) {
+    public void setupInventories(Collection<Player> players, Map<UUID, Role> roles, SparkSecondaryAbility sparkAbility, MedicSecondaryAbility medicAbility) {
         if (players == null || roles == null) {
             plugin.getLogger().warning("Cannot setup inventories: players or roles is null");
             return;
@@ -173,7 +182,7 @@ public class InventoryManager {
             }
             Role role = roles.get(player.getUniqueId());
             if (role != null) {
-                setupPlayerInventory(player, role, sparkAbility);
+                setupPlayerInventory(player, role, sparkAbility, medicAbility);
             }
         }
     }
@@ -577,6 +586,30 @@ public class InventoryManager {
         lore.add("§7Right-click to silently swap");
         lore.add("§7positions with a random player.");
         lore.add("§7Keeps both velocities.");
+        lore.add("§7Once per round.");
+
+        meta.setLore(lore);
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+        paper.setItemMeta(meta);
+        return makeUnmovable(paper);
+    }
+
+    /**
+     * Creates the Delusion ability paper.
+     */
+    private ItemStack createDelusionPaper() {
+        ItemStack paper = new ItemStack(Material.PAPER);
+        ItemMeta meta = paper.getItemMeta();
+        if (meta == null) {
+            return paper;
+        }
+
+        meta.setDisplayName("§5Delusion");
+        List<String> lore = new ArrayList<>();
+        lore.add("§7Right-click to activate an 8s window.");
+        lore.add("§7Then right-click a player to apply");
+        lore.add("§7a fake infection that medic can see.");
+        lore.add("§7a Decays after 1 minute.");
         lore.add("§7Once per round.");
 
         meta.setLore(lore);

--- a/src/main/java/com/ohacd/matchbox/game/utils/Managers/InventoryManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/Managers/InventoryManager.java
@@ -662,7 +662,7 @@ public class InventoryManager {
         lore.add("§7Right-click to activate an 8s window.");
         lore.add("§7Then right-click a player to apply");
         lore.add("§7a fake infection that the medic can see.");
-        lore.add("§7Decays after 1 minute.");
+        lore.add("§7Decays after 30 seconds.");
         lore.add("§7Once per round.");
 
         meta.setLore(lore);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,77 +10,62 @@ session:
   
   # Minimum number of spawn locations required before starting a game
   min-spawn-locations: 1
-  
-  # Game spawn locations (coordinates where players spawn at round start)
-  # Can be set via /matchbox setspawn <name> or configured here
-  # Format: world, x, y, z, yaw, pitch
   spawn-locations:
-  - world: world
-    x: -50.8562505032138
+  - world: m4tchb0x
+    x: -51.473426361396264
     y: -28.0
-    z: 161.53220990480872
-    pitch: -1.4964615
-    yaw: 0.3725586
-  - world: world
-    x: -52.73351247130995
+    z: 62.99461190591391
+    pitch: 0.69033235
+    yaw: 0.1887207
+  - world: m4tchb0x
+    x: -150.17946738772446
     y: -28.0
-    z: 255.22775887105558
-    pitch: 0.114887916
-    yaw: -179.96387
-  - world: world
-    x: -6.558074022330881
+    z: 56.40573214795135
+    pitch: 5.9847145
+    yaw: -29.963623
+  - world: m4tchb0x
+    x: -148.54268372924275
     y: -28.0
-    z: 208.71715784104558
-    pitch: 1.95642
-    yaw: 90.04712
-  - world: world
-    x: -149.0318268149002
+    z: 157.59044118502777
+    pitch: 0.69035906
+    yaw: -92.0
+  - world: m4tchb0x
+    x: -51.739567395775154
     y: -28.0
-    z: 156.60047567992828
-    pitch: 1.2658979
-    yaw: -89.94336
-  - world: world
-    x: -145.65882147418128
+    z: 255.41098517125434
+    pitch: 4.488498
+    yaw: -177.7445
+  - world: m4tchb0x
+    x: -4.691513152574944
     y: -28.0
-    z: 60.9582433094325
-    pitch: 4.2583613
-    yaw: -40.241455
-  - world: world
-    x: -50.94640213245196
+    z: 208.96547601851555
+    pitch: 4.258306
+    yaw: 90.31067
+  - world: m4tchb0x
+    x: 34.49659508040274
     y: -28.0
-    z: 65.57967602167355
-    pitch: 1.6112012
-    yaw: 0.8474121
-  - world: world
-    x: -12.853299896941419
+    z: 156.4157398922256
+    pitch: 6.560222
+    yaw: 90.77466
+  - world: m4tchb0x
+    x: -0.5183775312148339
     y: -28.0
-    z: 68.58756215846395
-    pitch: 6.3300858
-    yaw: -101.4751
-  - world: world
-    x: -0.6638734082145273
+    z: 113.5868217210009
+    pitch: 3.1073725
+    yaw: 1.0196533
+  - world: m4tchb0x
+    x: 34.3062856383851
     y: -28.0
-    z: 114.0285342048551
-    pitch: 4.603675
-    yaw: -2.7338867
-  - world: world
-    x: 35.01776788375859
+    z: 98.9279350023729
+    pitch: 5.1790857
+    yaw: 6.4093018
+  - world: m4tchb0x
+    x: 12.167055671992346
     y: -28.0
-    z: 156.51610727450935
-    pitch: 5.2942443
-    yaw: 91.049805
-  - world: world
-    x: 33.69344917063158
-    y: -28.0
-    z: 99.66568098214483
-    pitch: 15.3075075
-    yaw: 85.52905
-  - world: world
-    x: 13.456050482229537
-    y: -28.0
-    z: 69.35289177192249
-    pitch: 4.3735056
-    yaw: 91.85693
+    z: 70.27321679178925
+    pitch: 14.962158
+    yaw: 114.36682
+
 # Example:
 # - world: world
 #   x: 0.5
@@ -109,66 +94,6 @@ discussion:
   - 7
   - 8
   
-  # Seat locations (coordinates for each seat)
-  # Can be set via /matchbox setseat <name> <seat-number> or configured here
-  # Format: seat number, then world, x, y, z, yaw, pitch
-  seat-locations:
-    '1':
-      world: world
-      x: -129.131814985295
-      y: -26.5
-      z: 254.52635539512744
-      yaw: -90.11377
-      pitch: 2.9922788
-    '2':
-      world: world
-      x: -129.13709990454862
-      y: -26.5
-      z: 251.90142060573828
-      yaw: -90.11377
-      pitch: 2.9922788
-    '3':
-      world: world
-      x: -125.41551290002177
-      y: -26.5
-      z: 249.02583875200165
-      yaw: 0.69384766
-      pitch: 2.186616
-    '4':
-      world: world
-      x: -122.35331764513435
-      y: -26.5
-      z: 249.0628321728634
-      yaw: 0.69384766
-      pitch: 2.186616
-    '5':
-      world: world
-      x: -118.8420315201995
-      y: -26.5
-      z: 251.51947208186309
-      yaw: 89.18445
-      pitch: -2.532296
-    '6':
-      world: world
-      x: -118.80047601429517
-      y: -26.5
-      z: 254.6102972035724
-      yaw: 90.33667
-      pitch: -1.0360769
-    '7':
-      world: world
-      x: -122.72919660060212
-      y: -26.5
-      z: 257.0749253454155
-      yaw: -178.85303
-      pitch: -0.69077116
-    '8':
-      world: world
-      x: -125.52647074862402
-      y: -26.5
-      z: 257.17158451521794
-      yaw: -178.96729
-      pitch: -4.0284977
   # Example:
   # 1:
   #   world: world
@@ -187,6 +112,63 @@ discussion:
 
     # Discussion phase duration in seconds
   duration: 30
+  seat-locations:
+    '1':
+      world: m4tchb0x
+      x: -129.16343439943907
+      y: -26.5
+      z: 251.55774675779458
+      yaw: -89.37445
+      pitch: 1.611053
+    '2':
+      world: m4tchb0x
+      x: -129.1864844318363
+      y: -26.5
+      z: 254.36611360150775
+      yaw: -90.75531
+      pitch: 1.7261552
+    '3':
+      world: m4tchb0x
+      x: -125.52719780180495
+      y: -26.5
+      z: 257.0771164995616
+      yaw: 179.12561
+      pitch: 4.143142
+    '4':
+      world: m4tchb0x
+      x: -122.25339360180097
+      y: -26.5
+      z: 257.0268930333515
+      yaw: 179.12561
+      pitch: 4.143142
+    '5':
+      world: m4tchb0x
+      x: -119.0030134337861
+      y: -26.5
+      z: 254.59310772635314
+      yaw: 90.84845
+      pitch: 1.265751
+    '6':
+      world: m4tchb0x
+      x: -118.96102588929145
+      y: -26.5
+      z: 251.74950939174357
+      yaw: 90.84845
+      pitch: 1.265751
+    '7':
+      world: m4tchb0x
+      x: -122.2330839151841
+      y: -26.5
+      z: 248.93487004108408
+      yaw: 1.9953613
+      pitch: 0.11480462
+    '8':
+      world: m4tchb0x
+      x: -125.51700092500927
+      y: -26.5
+      z: 248.82053637494593
+      yaw: -0.19140625
+      pitch: 2.4167016
 
 # Spark Ability Settings
 spark:
@@ -209,11 +191,11 @@ voting:
   # Thresholds are calculated logarithmically between these key points
   threshold:
     # Threshold percentage at 20 players (0.20 = 20%)
-    at-20-players: 0.20
+    at-20-players: 0.2
     # Threshold percentage at 7 players (0.30 = 30%)
-    at-7-players: 0.30
+    at-7-players: 0.3
     # Threshold percentage at 3 players and below (0.50 = 50%)
-    at-3-players: 0.50
+    at-3-players: 0.5
   
   # Penalty system for voting phases without elimination
   penalty:
@@ -222,7 +204,7 @@ voting:
     # Maximum number of phases that can accumulate penalty
     max-phases: 3
     # Maximum penalty reduction percentage (0.10 = 10%)
-    max-reduction: 0.10
+    max-reduction: 0.1
 
 # Cosmetic Settings
 cosmetics:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -191,7 +191,13 @@ discussion:
 # Spark Ability Settings
 spark:
   # Spark secondary ability selection mode
-  # Options: "random" (default - randomly selects each round), "hunter_vision", "spark_swap"
+  # Options: "random" (default - randomly selects each round), "hunter_vision", "spark_swap", "delusion"
+  secondary-ability: random
+
+# Medic Ability Settings
+medic:
+  # Medic secondary ability selection mode
+  # Options: "random" (default - randomly selects each round), "healing_sight"
   secondary-ability: random
 
 # Voting Phase Settings
@@ -223,10 +229,10 @@ cosmetics:
   # Enable/disable random skin assignment for players during games
   # When enabled, players will receive random skins at game start
   # When disabled, players will keep their original skins
-  random-skins-enabled: true
+  random-skins-enabled: false
   
   # Use Steve (default) skins for all players during games
   # When enabled, all players will have the default Steve skin regardless of random-skins-enabled setting
   # When disabled, random skins or original skins will be used based on random-skins-enabled
-  use-steve-skins: false
+  use-steve-skins: true
 


### PR DESCRIPTION
## [0.9.4] - Latest Release (Ability System)

### Added
- **Medic Secondary Ability System**: Medic now uses the same ability system as Spark
  - Healing Sight is now tracked as a secondary ability (preparing for future abilities)
  - System modeled after the Spark secondary ability system for consistency
  - Configurable via `medic.secondary-ability` in config.yml
  - Options: "random" (default), "healing_sight"
  - Ready for future medic abilities to be added
- **Delusion Ability**: New Spark secondary ability that creates fake infections
  - Spark can activate an 8-second window, then right-click a player to apply a fake infection
  - Fake infections appear identical to real infections to the medic (same particles)
  - Medic can see delusion infections using Healing Sight alongside real infections
  - Medic can cure delusion infections, wasting their cure on a non-infected player
  - Delusion infections automatically decay after 30 seconds
  - Delusion infections do not cause elimination when discussion phase starts
  - Configurable via `spark.secondary-ability` in config.yml
  - Options: "random" (default), "hunter_vision", "spark_swap", "delusion"

### Changed
- **Medic Ability System Architecture**: Refactored medic abilities to match Spark's system
  - Created `MedicSecondaryAbility` enum for ability tracking
  - Added ability selection logic in GameManager
  - Updated InventoryManager to handle medic abilities dynamically
  - MedicSightListener now checks if ability is active before allowing use
  - System is now extensible for adding new medic abilities in the future
- **Config steve skin override**: Default config now comes with steve skin override as true by default
  - Random skin toggle is now set to false by default
- **Debug command**: Fake infected (Delusion infection) is tracked by the debug command
  - Added the fake infected param to `/matchbox debug` command

### Fixed
- **Steve Skin Override**: Fixed inconsistent steve skin application
  - All players now consistently receive steve skins when enabled
  - Skins are reapplied at the start of each new round to ensure consistency
  - Fixed issue where some players would get alex or random skins instead of steve
- **Invalid default seat locations**: Fixed an error where default seat locations weren't loading correctly when used with the `m4tchb0x` map
  - Default Spawn/Seat locations are no longer linked to a world folder named `world` 
  - Now linked to a world folder named `m4tchb0x`
