### PR TITLE
0.9.6: Finalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to the Matchbox plugin will be documented in this file.
 
+## [0.9.6] - Development (Nick System, Sign Mode, Skin & Stability)
+
+Players can now compete under custom nicknames, communicate via signs during the swipe phase, and benefit from a more consistent and reliable game experience.
+
+### Nick System
+
+- **Set a nick** — pick any name (3–16 characters, letters/numbers/`_`/`-`) and it becomes your identity for the duration of the game. Your nick shows in chat, the player list, and above your head.
+- **Random nick** — generates a realistic-looking username from a curated word list in styles like `FrostWolf`, `frost_wolf`, `FROST_Wolf`, or `frostWolf`. A numeric suffix is added automatically if the generated name is already taken.
+- **Session-scoped** — nicks activate when a game starts and are removed the moment the game ends, you leave, or you disconnect. No carry-over between games.
+- **Unique per session** — no two players in the same game can share a nick. The second player to claim a taken nick is blocked and told to pick another.
+- **Persistent preference** — your chosen nick is saved across restarts. You only need to set it once.
+- **Action bar reminder** — while outside a game, a subtle `Currently Nicked as: [Nick]` message sits above your hotbar so you always know what name you're carrying.
+- **Admins** (`matchbox.admin`) can set, randomise, or reset any player's nick.
+
+| Command | Who | What it does |
+|---|---|---|
+| `/mb nick` | anyone | See your current nick |
+| `/mb nick <name>` | anyone | Set your nick |
+| `/mb nick random` | anyone | Get a randomly generated nick |
+| `/mb nick reset` | anyone | Remove your nick |
+| `/mb nick <player> <name>` | admin | Set another player's nick |
+| `/mb nick reset <player>` | admin | Remove another player's nick |
+| `/mb nick random <player>` | admin | Generate a random nick for another player |
+
+### Sign Mode
+
+- **Signs as communication** — when `sign-mode.enabled: true`, players communicate by placing signs during the swipe phase instead of typing in chat. Each player receives a sign kit at the start of swipe.
+- **Automatic cleanup** — all placed signs are removed when discussion begins or the game ends. Nothing is left behind in the world.
+- **Chat bypass** — normal in-game chat is suppressed when sign mode is on, so signs are the only intended channel.
+- **Join message toggle** (`join-message.enabled`) — server owners can disable the welcome title/message shown on join without affecting version notifications.
+
+### Skin & Visual Changes
+
+- Skin rendering upgraded to use ProtocolLib player-info packet rewrites for more consistent updates across clients.
+- Steve fallback improved — when skin lookups fail (offline mode or API unavailable), all players receive a consistent classic Steve skin rather than a mix of random fallbacks.
+- Paper compatibility raised to **1.21.11**.
+
+### Bug Fixes
+
+- **Eliminated players no longer appear in game chat** — they were being cached as alive in the chat pipeline after death. The cache is now cleared on elimination.
+- **Arrow tracking is now per-session** — a round reset in one game no longer clears arrow-used state for players in a different concurrent session.
+- **Players with failed state backups are excluded from the game** — previously, if saving a player's inventory or location failed, they were still added to the alive roster and couldn't be restored at game end.
+- **Win screen shows the Spark's name, not their UUID** — when the Spark disconnects and the game ends, the win announcement now resolves their name correctly.
+- **Delusion decay timer now cancels on session end** — the 30-second task scheduled when Delusion was used was not being tracked. It is now cancelled alongside other session tasks on cleanup.
+- **Random skin preloading no longer silently fails** — UUID format issues during cached skin loading are handled correctly.
+- **Hologram cleanup is safe during shutdown** — no new scheduler tasks are created while the plugin is disabling.
+- **Session player limit fixed** — min/max validation now correctly accepts the full `2–20` range.
+- **Default spawn world corrected** — default config now references `m4tchbox` instead of the old typo `m4tchb0x`.
+
+
+
 ## [0.9.5] - Latest Release (API Module & Testing Suite)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Tags:** Paper, Minecraft 1.21.10, Minigame, Social Deduction, Plugin
+**Tags:** Paper, Minecraft 1.21.11, Minigame, Social Deduction, Plugin
 
 # Matchbox — Social Deduction Minigame for Paper
 
@@ -62,6 +62,7 @@ The game repeats until either:
 - Drop-in ready — ships with a complete default config for the official map
 - Highly configurable — phases, abilities, voting, cosmetics, chat routing
 - Nickname-friendly UI — titles, holograms, voting papers use display names
+- Built-in nick system — players compete under custom aliases with session-scoped uniqueness enforcement
 
 ---
 
@@ -80,11 +81,12 @@ The plugin ships with a fully pre-configured default setup for the M4tchb0x map:
 - Discussion seats
 - Phase timings
 - Player limits
+- Sign mode enabled by default (`sign-mode.enabled: true`)
 
 You can start playing immediately or customize everything in-game.
 
 **Requirements:**  
-Paper 1.21.10 · Java 21+ · 2–20 players
+Paper 1.21.11 · Java 21+ · 2–20 players
 
 ---
 
@@ -94,6 +96,7 @@ Paper 1.21.10 · Java 21+ · 2–20 players
 - `/matchbox join <session>`
 - `/matchbox leave`
 - `/matchbox list`
+- `/matchbox nick [name|random|reset]`
 
 **Admins**
 - `/matchbox start <session>`

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'com.ohacd'
-version = '0.9.5'
+version = '0.9.6'
 
 repositories {
     mavenCentral()
@@ -12,20 +12,23 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.10-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
     compileOnly ("net.dmulloy2:ProtocolLib:5.4.0")
     
     // Testing dependencies
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
-    testImplementation("org.mockito:mockito-core:5.5.0")
-    testImplementation("org.mockito:mockito-junit-jupiter:5.5.0")
+    testImplementation("org.mockito:mockito-core:5.11.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.11.0")
     testImplementation("org.assertj:assertj-core:3.24.2")
     // Add main classes to test classpath for Bukkit imports
-    testImplementation("io.papermc.paper:paper-api:1.21.10-R0.1-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    testImplementation("net.dmulloy2:ProtocolLib:5.4.0")
 }
 
 test {
     useJUnitPlatform()
+    // Mockito inline mocking depends on ByteBuddy class instrumentation; allow newer JDKs.
+    jvmArgs "-Dnet.bytebuddy.experimental=true"
     
     testLogging {
         events "passed", "skipped", "failed"
@@ -47,7 +50,7 @@ tasks {
         // Configure the Minecraft version for our task.
         // This is the only required configuration besides applying the plugin.
         // Your plugin's jar (or shadowJar if present) will be used automatically.
-        minecraftVersion("1.21.10")
+        minecraftVersion("1.21.11")
     }
 }
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -6,7 +6,7 @@ This guide will help you install and set up Matchbox on your server.
 
 Before you begin, make sure you have:
 
-- **Minecraft Server**: Paper 1.21.10 or higher ([Download Paper](https://papermc.io/downloads))
+- **Minecraft Server**: Paper 1.21.11 or higher ([Download Paper](https://papermc.io/downloads))
 - **Java**: Version 21 or higher
 - **Dependencies**: ProtocolLib 5.4.0 or higher ([Download](https://www.spigotmc.org/resources/protocollib.1997/))
 - **Map** (Optional): M4tchb0x official map ([Download](https://www.planetminecraft.com/project/m4tchb0x-maps/))

--- a/src/main/java/com/ohacd/matchbox/Matchbox.java
+++ b/src/main/java/com/ohacd/matchbox/Matchbox.java
@@ -28,6 +28,9 @@ import com.ohacd.matchbox.game.utils.listeners.PlayerJoinListener;
 import com.ohacd.matchbox.game.utils.listeners.PlayerQuitListener;
 import com.ohacd.matchbox.game.utils.listeners.VoteItemListener;
 import com.ohacd.matchbox.game.utils.listeners.VotePaperListener;
+import com.ohacd.matchbox.game.nick.NickManager;
+import com.ohacd.matchbox.game.sign.SignModeManager;
+import com.ohacd.matchbox.game.sign.SignModeListener;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -40,7 +43,7 @@ import java.util.Set;
 public final class Matchbox extends JavaPlugin {
     // Project status, versioning and update name
     private static final ProjectStatus projectStatus = ProjectStatus.STABLE; // Main toggle for project status
-    private String updateName = "API Module & Testing Suite";
+    private String updateName = "QOL Improvements"; 
     private String currentVersion;
     private CheckProjectVersion versionChecker;
 
@@ -60,6 +63,29 @@ public final class Matchbox extends JavaPlugin {
         this.versionChecker = new CheckProjectVersion(this);
         this.currentVersion = getInstance().getPluginMeta().getVersion();
 
+        // Initialise sign mode (inject into GameManager so it can use it)
+        SignModeManager signModeManager = new SignModeManager(this);
+        gameManager.setSignModeManager(signModeManager);
+
+        // Initialise nick system (inject into GameManager so it can apply/restore nicks)
+        NickManager nickManager = new NickManager(this);
+        gameManager.setNickManager(nickManager);
+
+        // Repeating task: show action bar reminder to any player who has a nick stored.
+        // Suppressed while the player is inside an active game session (phases have their own action bar).
+        getServer().getScheduler().runTaskTimer(this, () -> {
+            for (org.bukkit.entity.Player p : getServer().getOnlinePlayers()) {
+                String nick = nickManager.getNick(p.getUniqueId());
+                if (nick == null) continue;
+                // Don't show while a game session is active for this player
+                com.ohacd.matchbox.game.SessionGameContext ctx =
+                        gameManager.getContextForPlayer(p.getUniqueId());
+                if (ctx != null && ctx.getGameState().isGameActive()) continue;
+                p.sendActionBar(net.kyori.adventure.text.Component.text(
+                        "§7Currently Nicked as: §a" + nick));
+            }
+        }, 40L, 40L); // start after 2 s, repeat every 2 s (action bar fades after ~3 s)
+
         // Register event listeners
         getServer().getPluginManager().registerEvents(new ChatListener(hologramManager, gameManager), this);
         getServer().getPluginManager().registerEvents(
@@ -68,6 +94,7 @@ public final class Matchbox extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new DamageProtectionListener(gameManager), this);
         getServer().getPluginManager().registerEvents(new BlockInteractionProtectionListener(gameManager), this);
         getServer().getPluginManager().registerEvents(new PotBreakProtectionListener(gameManager), this);
+        getServer().getPluginManager().registerEvents(new SignModeListener(gameManager, signModeManager), this);
 
         // Register abilities through a single event router
         abilityManager.registerAbility(new SwipeActivationListener(gameManager, this));
@@ -90,7 +117,7 @@ public final class Matchbox extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new PlayerJoinListener(this, versionChecker), this);
 
         // Register command handler
-        MatchboxCommand commandHandler = new MatchboxCommand(this, sessionManager, gameManager);
+        MatchboxCommand commandHandler = new MatchboxCommand(this, sessionManager, gameManager, nickManager);
         getCommand("matchbox").setExecutor(commandHandler);
         getCommand("matchbox").setTabCompleter(commandHandler);
 

--- a/src/main/java/com/ohacd/matchbox/command/MatchboxCommand.java
+++ b/src/main/java/com/ohacd/matchbox/command/MatchboxCommand.java
@@ -3,6 +3,8 @@ package com.ohacd.matchbox.command;
 import com.ohacd.matchbox.Matchbox;
 import com.ohacd.matchbox.game.GameManager;
 import com.ohacd.matchbox.game.SessionGameContext;
+import com.ohacd.matchbox.game.nick.NickManager;
+import com.ohacd.matchbox.game.nick.RandomNickGenerator;
 import com.ohacd.matchbox.game.session.GameSession;
 import com.ohacd.matchbox.game.session.SessionManager;
 import com.ohacd.matchbox.game.utils.GamePhase;
@@ -19,6 +21,7 @@ import org.bukkit.Bukkit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,10 +35,11 @@ import java.util.stream.Collectors;
 public class MatchboxCommand implements CommandExecutor, TabCompleter {
     private final SessionManager sessionManager;
     private final GameManager gameManager;
+    private final NickManager nickManager;
     // Track pending confirmations for destructive commands
     private final Map<UUID, String> pendingConfirmations = new ConcurrentHashMap<>();
 
-    public MatchboxCommand(Matchbox plugin, SessionManager sessionManager, GameManager gameManager) {
+    public MatchboxCommand(Matchbox plugin, SessionManager sessionManager, GameManager gameManager, NickManager nickManager) {
         if (sessionManager == null) {
             throw new IllegalArgumentException("SessionManager cannot be null");
         }
@@ -44,6 +48,7 @@ public class MatchboxCommand implements CommandExecutor, TabCompleter {
         }
         this.sessionManager = sessionManager;
         this.gameManager = gameManager;
+        this.nickManager = nickManager;
     }
 
     @Override
@@ -96,6 +101,8 @@ public class MatchboxCommand implements CommandExecutor, TabCompleter {
                 return handleDebug(sender);
             case "skip":
                 return handleSkip(sender);
+            case "nick":
+                return handleNick(sender, args);
             default:
                 sendHelp(sender);
                 return true;
@@ -960,6 +967,7 @@ public class MatchboxCommand implements CommandExecutor, TabCompleter {
         sender.sendMessage("§e/matchbox join <name> §7- Join a game session");
         sender.sendMessage("§e/matchbox remove <name> §7- Remove a session (deprecated, use stop)");
         sender.sendMessage("§e/matchbox leave <name> §7- Leave a game session");
+        sender.sendMessage("§e/matchbox nick [name|random|reset] §7- Manage your in-game nick");
         sender.sendMessage("§e/matchbox setdiscussion <name> §7- Set discussion location");
         sender.sendMessage("§e/matchbox setspawn §7- Add a spawn location to config");
         sender.sendMessage("§e/matchbox setseat <number> §7- Set a seat location to config");
@@ -979,7 +987,7 @@ public class MatchboxCommand implements CommandExecutor, TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            List<String> subCommands = Arrays.asList("start", "begin", "debugstart", "stop", "join", "leave", "setdiscussion", "setspawn", "setseat", "list", "listspawns", "listseatspawns", "removespawn", "removeseat", "clearspawns", "clearseats", "remove", "cleanup", "debug", "skip");
+            List<String> subCommands = Arrays.asList("start", "begin", "debugstart", "stop", "join", "leave", "nick", "setdiscussion", "setspawn", "setseat", "list", "listspawns", "listseatspawns", "removespawn", "removeseat", "clearspawns", "clearseats", "remove", "cleanup", "debug", "skip");
             return subCommands.stream()
                     .filter(cmd -> cmd.startsWith(args[0].toLowerCase()))
                     .collect(Collectors.toList());
@@ -987,6 +995,12 @@ public class MatchboxCommand implements CommandExecutor, TabCompleter {
 
         if (args.length == 2) {
             String subCommand = args[0].toLowerCase();
+            if (subCommand.equals("nick")) {
+                List<String> nickSubs = Arrays.asList("reset", "random");
+                return nickSubs.stream()
+                        .filter(s -> s.startsWith(args[1].toLowerCase()))
+                        .collect(Collectors.toList());
+            }
             if (subCommand.equals("begin") || subCommand.equals("debugstart") || subCommand.equals("stop") || subCommand.equals("join") ||
                     subCommand.equals("leave") || subCommand.equals("setdiscussion") ||
                     subCommand.equals("setspawn") || subCommand.equals("setseat") || subCommand.equals("remove")) {
@@ -996,6 +1010,192 @@ public class MatchboxCommand implements CommandExecutor, TabCompleter {
             }
         }
 
+        if (args.length == 3 && args[0].equalsIgnoreCase("nick")) {
+            // /mb nick reset <player> or /mb nick random <player> or /mb nick <player> <nick>
+            String arg1 = args[1].toLowerCase();
+            if (arg1.equals("reset") || arg1.equals("random") || sender.hasPermission("matchbox.admin")) {
+                return Bukkit.getOnlinePlayers().stream()
+                        .map(Player::getName)
+                        .filter(n -> n.toLowerCase().startsWith(args[2].toLowerCase()))
+                        .collect(Collectors.toList());
+            }
+        }
+
         return Collections.emptyList();
+    }
+
+    // =========================================================
+    // /mb nick handler
+    // =========================================================
+
+    private boolean handleNick(CommandSender sender, String[] args) {
+        if (nickManager == null) {
+            sender.sendMessage("§cNick system is not available.");
+            return true;
+        }
+
+        // /mb nick  — show current nick
+        if (args.length == 1) {
+            if (!(sender instanceof Player player)) {
+                sender.sendMessage("§cThis command can only be used by players.");
+                return true;
+            }
+            String current = nickManager.getNick(player.getUniqueId());
+            if (current == null) {
+                sender.sendMessage("§7You have no nick set. Use §e/mb nick <name>§7 to set one, or §e/mb nick random§7 to get one.");
+            } else {
+                sender.sendMessage("§7Your current nick: " + current + "§7. Use §e/mb nick reset§7 to remove it.");
+            }
+            return true;
+        }
+
+        String arg1 = args[1];
+
+        // /mb nick reset [player]  — remove nick
+        if (arg1.equalsIgnoreCase("reset")) {
+            if (args.length >= 3) {
+                // Admin: reset another player's nick
+                if (!sender.hasPermission("matchbox.admin")) {
+                    sender.sendMessage("§cYou don't have permission to reset other players' nicks.");
+                    return true;
+                }
+                Player target = Bukkit.getPlayer(args[2]);
+                if (target == null) {
+                    sender.sendMessage("§cPlayer '§e" + args[2] + "§c' not found or is offline.");
+                    return true;
+                }
+                nickManager.removeNick(target.getUniqueId());
+                applyOrRestoreNickInSession(target);
+                sender.sendMessage("§aNick reset for §e" + target.getName() + "§a.");
+                target.sendMessage("§7Your nick has been reset by an admin.");
+            } else {
+                // Self: reset own nick
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage("§cThis command can only be used by players.");
+                    return true;
+                }
+                nickManager.removeNick(player.getUniqueId());
+                applyOrRestoreNickInSession(player);
+                sender.sendMessage("§aYour nick has been reset.");
+            }
+            return true;
+        }
+
+        // /mb nick random [player]  — generate a random nick
+        if (arg1.equalsIgnoreCase("random")) {
+            if (args.length >= 3) {
+                // Admin: random nick for another player
+                if (!sender.hasPermission("matchbox.admin")) {
+                    sender.sendMessage("§cYou don't have permission to set nicks for other players.");
+                    return true;
+                }
+                Player target = Bukkit.getPlayer(args[2]);
+                if (target == null) {
+                    sender.sendMessage("§cPlayer '§e" + args[2] + "§c' not found or is offline.");
+                    return true;
+                }
+                String nick = RandomNickGenerator.generateUnique(buildGlobalTakenNicks(target.getUniqueId()));
+                nickManager.setNick(target.getUniqueId(), nick, true);
+                applyOrRestoreNickInSession(target);
+                sender.sendMessage("§aGenerated nick §e" + nick + "§a for §e" + target.getName() + "§a.");
+                target.sendMessage("§7Your nick has been set to §e" + nick + "§7 by an admin.");
+            } else {
+                // Self: random nick
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage("§cThis command can only be used by players.");
+                    return true;
+                }
+                String nick = RandomNickGenerator.generateUnique(buildGlobalTakenNicks(player.getUniqueId()));
+                nickManager.setNick(player.getUniqueId(), nick, player.hasPermission("matchbox.admin"));
+                applyOrRestoreNickInSession(player);
+                sender.sendMessage("§aYour nick has been set to §e" + nick + "§a.");
+            }
+            return true;
+        }
+
+        // /mb nick <player> <nick>  — admin set nick for another player (3 args)
+        if (args.length >= 3 && sender.hasPermission("matchbox.admin")) {
+            Player target = Bukkit.getPlayer(arg1);
+            if (target != null) {
+                String nick = args[2];
+                NickManager.NickResult result = nickManager.setNick(target.getUniqueId(), nick, true);
+                if (result != NickManager.NickResult.SUCCESS) {
+                    sendNickError(sender, result);
+                    return true;
+                }
+                applyOrRestoreNickInSession(target);
+                sender.sendMessage("§aSet nick §e" + nick + "§a for §e" + target.getName() + "§a.");
+                target.sendMessage("§7Your nick has been set to §e" + nick + "§7 by an admin.");
+                return true;
+            }
+        }
+
+        // /mb nick <nickname>  — set own nick
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("§cThis command can only be used by players.");
+            return true;
+        }
+        boolean isAdmin = player.hasPermission("matchbox.admin");
+        NickManager.NickResult result = nickManager.setNick(player.getUniqueId(), arg1, isAdmin);
+        if (result != NickManager.NickResult.SUCCESS) {
+            sendNickError(sender, result);
+            return true;
+        }
+        applyOrRestoreNickInSession(player);
+        sender.sendMessage("§aYour nick has been set to §e" + arg1 + "§a.");
+        return true;
+    }
+
+    /**
+     * If the player is currently in an active game session, applies (or restores) their
+     * nick immediately so the change is visible without waiting for the next game start.
+     */
+    private void applyOrRestoreNickInSession(Player player) {
+        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
+        if (context == null || !context.getGameState().isGameActive()) return;
+
+        String nick = nickManager.getNick(player.getUniqueId());
+        if (nick == null) {
+            // Nick was removed — restore real name
+            nickManager.restoreNick(player);
+            return;
+        }
+
+        // Restore first to release any previously held nick slot, then re-apply
+        nickManager.restoreNick(player);
+        Set<String> taken = nickManager.getTakenNicksInSession(
+                context.getGameState().getAllParticipatingPlayerIds());
+        taken.remove(nick.toLowerCase()); // allow the player to (re-)claim their own nick
+        if (!nickManager.applyNick(player, taken)) {
+            player.sendMessage("§cThat nick is already used by another player in this session. Use §e/mb nick random§c for a unique one.");
+            nickManager.removeNick(player.getUniqueId());
+        }
+    }
+
+    /**
+     * Builds a lower-case set of all nicks currently in use across every active session,
+     * excluding the given UUID (so a player can re-nick themselves without self-conflict).
+     */
+    private Set<String> buildGlobalTakenNicks(UUID exclude) {
+        Set<String> taken = new HashSet<>();
+        for (String sessionName : gameManager.getActiveSessionNames()) {
+            SessionGameContext ctx = gameManager.getContext(sessionName);
+            if (ctx == null) continue;
+            for (UUID id : ctx.getGameState().getAllParticipatingPlayerIds()) {
+                if (id.equals(exclude)) continue;
+                String nick = nickManager.getNick(id);
+                if (nick != null) taken.add(nick.toLowerCase());
+            }
+        }
+        return taken;
+    }
+
+    private void sendNickError(CommandSender sender, NickManager.NickResult result) {
+        switch (result) {
+            case TOO_SHORT  -> sender.sendMessage("§cNick too short. Minimum 3 characters.");
+            case TOO_LONG   -> sender.sendMessage("§cNick too long. Maximum 16 characters.");
+            case INVALID_CHARS -> sender.sendMessage("§cInvalid characters. Use only letters, numbers, §e_§c and §e-§c.");
+            default         -> sender.sendMessage("§cFailed to set nick.");
+        }
     }
 }

--- a/src/main/java/com/ohacd/matchbox/game/GameManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/GameManager.java
@@ -18,6 +18,8 @@ import com.ohacd.matchbox.game.phase.SwipePhaseHandler;
 import com.ohacd.matchbox.game.phase.VotingPhaseHandler;
 import com.ohacd.matchbox.game.session.GameSession;
 import com.ohacd.matchbox.game.session.SessionManager;
+import com.ohacd.matchbox.game.nick.NickManager;
+import com.ohacd.matchbox.game.sign.SignModeManager;
 import com.ohacd.matchbox.game.state.GameState;
 import com.ohacd.matchbox.game.utils.GamePhase;
 import com.ohacd.matchbox.game.utils.MessageUtils;
@@ -67,6 +69,12 @@ public class GameManager {
     private final SkinManager skinManager;
     private final HunterVisionAdapter hunterVisionAdapter;
     private final ChatPipelineManager chatPipelineManager;
+
+    // Sign mode — injected after construction via setSignModeManager()
+    private SignModeManager signModeManager;
+
+    // Nick system — injected after construction via setNickManager()
+    private NickManager nickManager;
 
     // Active game sessions - each session has its own game state and context
     private final Map<String, SessionGameContext> activeSessions = new ConcurrentHashMap<>();
@@ -284,6 +292,15 @@ public class GameManager {
         // Clear all player backups
         playerBackups.clear();
 
+        // Clear all tracked signs
+        if (signModeManager != null) {
+            try {
+                signModeManager.clearAll();
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to clear sign mode manager during emergency cleanup: " + e.getMessage());
+            }
+        }
+
         plugin.getLogger().info("Emergency cleanup completed. Removed " + sessionNames.size() + " session(s).");
     }
 
@@ -375,6 +392,21 @@ public class GameManager {
         } else if (configManager.isRandomSkinsEnabled()) {
             // Apply random skins if enabled
             skinManager.applyRandomSkins(players);
+        }
+
+        // Apply nicks for all session players (session-scoped, uniqueness enforced)
+        if (nickManager != null) {
+            java.util.Set<String> takenNicks = new java.util.HashSet<>();
+            for (Player player : players) {
+                if (player == null || !player.isOnline()) continue;
+                String nick = nickManager.getNick(player.getUniqueId());
+                if (nick == null) continue;
+                if (!nickManager.applyNick(player, takenNicks)) {
+                    player.sendMessage("§eYour nick §7" + nick + "§e is already taken in this session. You'll play as your real name.");
+                } else {
+                    takenNicks.add(nick.toLowerCase());
+                }
+            }
         }
 
         // Start first round (teleport players and begin swipe phase)
@@ -491,6 +523,12 @@ public class GameManager {
                 }
             }
             inventoryManager.setupInventories(alivePlayers, roleMap, sparkAbility, medicAbility);
+
+            // Give sign-mode items after normal inventory setup if sign mode is enabled
+            if (isSignModeEnabled() && signModeManager != null) {
+                signModeManager.giveSignItems(alivePlayers);
+                plugin.getLogger().info("Sign mode is active for session '" + sessionName + "' — gave sign items to " + alivePlayers.size() + " player(s)");
+            }
         }
 
         // Hide the name tag for all alive players on phase start
@@ -626,6 +664,56 @@ public class GameManager {
 
     public HunterVisionAdapter getHunterVisionAdapter() {
         return hunterVisionAdapter;
+    }
+
+    /**
+     * Injects the {@link SignModeManager} after construction.
+     * Called from {@link com.ohacd.matchbox.Matchbox#onEnable()}.
+     */
+    public void setSignModeManager(SignModeManager signModeManager) {
+        this.signModeManager = signModeManager;
+    }
+
+    /**
+     * Injects the {@link NickManager} after construction.
+     * Called from {@link com.ohacd.matchbox.Matchbox#onEnable()}.
+     */
+    public void setNickManager(NickManager nickManager) {
+        this.nickManager = nickManager;
+    }
+
+    /**
+     * Restores a player's nick visuals (display name, tab name, custom name).
+     * Safe to call even if NickManager has not been injected.
+     */
+    public void restorePlayerNick(Player player) {
+        if (nickManager != null) {
+            nickManager.restoreNick(player);
+        }
+    }
+
+    /**
+     * Returns {@code true} if sign mode is enabled in the config.
+     * Safe to call from any listener; returns {@code false} if ConfigManager is unavailable.
+     */
+    public boolean isSignModeEnabled() {
+        return configManager != null && configManager.isSignModeEnabled();
+    }
+
+    /**
+     * Returns {@code true} if the given item is a sign-mode item created by
+     * {@link SignModeManager} (identified by its PDC tag).
+     * Returns {@code false} if SignModeManager has not been injected yet.
+     */
+    public boolean isSignModeItem(org.bukkit.inventory.ItemStack item) {
+        return signModeManager != null && signModeManager.isSignModeItem(item);
+    }
+
+    /**
+     * Returns the {@link SignModeManager}, or {@code null} if not yet injected.
+     */
+    public SignModeManager getSignModeManager() {
+        return signModeManager;
     }
 
     /**
@@ -859,6 +947,15 @@ public class GameManager {
         if (context == null) {
             plugin.getLogger().warning("Cannot start discussion phase - no context for session: " + sessionName);
             return;
+        }
+
+        // Clean up all signs placed during the swipe phase before discussion begins
+        if (isSignModeEnabled() && signModeManager != null) {
+            try {
+                signModeManager.clearSessionSigns(sessionName);
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to clear session signs for '" + sessionName + "': " + e.getMessage());
+            }
         }
 
         GameState gameState = context.getGameState();
@@ -1524,9 +1621,24 @@ public class GameManager {
         // Remove from alive set
         gameState.removeAlivePlayer(playerId);
 
-        // when a player gets eliminated they show their name tag
+        // Invalidate alive-status cache in the chat pipeline so the eliminated
+        // player's messages are routed to the spectator channel, not game chat
         try {
-            NameTagManager.showNameTag(player);
+            com.ohacd.matchbox.game.chat.SessionChatHandler chatHandler =
+                chatPipelineManager.getSessionHandler(sessionName);
+            if (chatHandler != null) {
+                chatHandler.invalidateCache(playerId);
+            }
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to invalidate chat cache for eliminated player: " + e.getMessage());
+        }
+
+        // when a player gets eliminated: if they have a nick the custom-name is already
+        // visible above their head (real nametag stays hidden), otherwise reveal it normally
+        try {
+            if (nickManager == null || nickManager.getNick(playerId) == null) {
+                NameTagManager.showNameTag(player);
+            }
         } catch (Exception e) {
             plugin.getLogger().warning("Failed to show nametag for eliminated player " + player.getName() + ": " + e.getMessage());
         }
@@ -1616,6 +1728,7 @@ public class GameManager {
 
         // Restore nametag and cosmetic overrides
         try {
+            if (nickManager != null) nickManager.restoreNick(player);
             NameTagManager.showNameTag(player);
         } catch (Exception e) {
             plugin.getLogger().warning("Failed to restore nametag for " + player.getName() + ": " + e.getMessage());
@@ -1736,6 +1849,15 @@ public class GameManager {
             return;
         }
 
+        // Clean up any signs remaining from the current round before ending
+        if (signModeManager != null) {
+            try {
+                signModeManager.clearSessionSigns(sessionName);
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to clear session signs during endGame for '" + sessionName + "': " + e.getMessage());
+            }
+        }
+
         GameState gameState = context.getGameState();
         PhaseManager phaseManager = context.getPhaseManager();
 
@@ -1760,7 +1882,8 @@ public class GameManager {
                     }
 
                     try {
-                        // Show nametag
+                        // Restore nick visuals then show real nametag
+                        if (nickManager != null) nickManager.restoreNick(player);
                         NameTagManager.showNameTag(player);
                     } catch (Exception e) {
                         plugin.getLogger().warning("Failed to restore nametag for " + player.getName() + ": " + e.getMessage());

--- a/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
+++ b/src/main/java/com/ohacd/matchbox/game/SessionGameContext.java
@@ -7,6 +7,7 @@ import com.ohacd.matchbox.game.vote.VoteManager;
 import com.ohacd.matchbox.game.win.WinConditionChecker;
 import org.bukkit.Location;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +45,9 @@ public class SessionGameContext {
     
     /** Number of consecutive voting phases that ended without elimination */
     private int consecutiveNoEliminationPhases = 0;
+
+    /** Scheduled tasks that should be cancelled when this session ends */
+    private final List<BukkitTask> scheduledTasks = new ArrayList<>();
     
     public SessionGameContext(Plugin plugin, String sessionName) {
         if (sessionName == null || sessionName.trim().isEmpty()) {
@@ -133,9 +137,28 @@ public class SessionGameContext {
     }
     
     /**
+     * Tracks a scheduled task so it is cancelled when this session ends.
+     */
+    public void trackTask(BukkitTask task) {
+        if (task != null) {
+            scheduledTasks.add(task);
+        }
+    }
+
+    /**
      * Cleans up all resources for this session context.
      */
     public void cleanup() {
+        for (BukkitTask task : scheduledTasks) {
+            try {
+                if (!task.isCancelled()) {
+                    task.cancel();
+                }
+            } catch (Exception ignored) {
+                // Best-effort cancellation
+            }
+        }
+        scheduledTasks.clear();
         activeSwipeWindow.clear();
         activeCureWindow.clear();
         activeDelusionWindow.clear();

--- a/src/main/java/com/ohacd/matchbox/game/action/PlayerActionHandler.java
+++ b/src/main/java/com/ohacd/matchbox/game/action/PlayerActionHandler.java
@@ -289,7 +289,7 @@ public class PlayerActionHandler {
         // Close the delusion window
         activeDelusionWindow.remove(sparkId);
         
-        // Schedule decay after 1 minute (60 seconds)
+        // Schedule decay after 30 seconds; track the task so it is cancelled if the session ends early
         final UUID targetIdFinal = targetId;
         final String sessionName = context.getSessionName();
         final SessionGameContext contextFinal = context;
@@ -303,13 +303,12 @@ public class PlayerActionHandler {
                 
                 GameState state = contextFinal.getGameState();
                 if (state.isDelusionInfected(targetIdFinal)) {
-                    // Remove delusion infection after 30 seconds
                     state.removeDelusionInfection(targetIdFinal);
                     plugin.getLogger().info("Delusion infection decayed for player " + targetIdFinal + " in session '" + sessionName + "'");
                 }
             }
         };
-        decayTask.runTaskLater(plugin, 20L * 30); // 30 seconds = 600 ticks
+        context.trackTask(decayTask.runTaskLater(plugin, 20L * 30)); // 30 seconds = 600 ticks
         
         plugin.getLogger().info("Delusion registered in session '" + context.getSessionName() + "': " + spark.getName() + " applied delusion to " + target.getName() + " (will decay in 1 minute)");
     }

--- a/src/main/java/com/ohacd/matchbox/game/chat/ChatListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/chat/ChatListener.java
@@ -58,6 +58,15 @@ public class ChatListener implements Listener {
             return;
         }
 
+        // Sign mode sessions intentionally avoid the chat pipeline during active games.
+        // Swipe chat remains blocked so players use signs for communication.
+        if (context.getGameState().isGameActive() && gameManager.isSignModeEnabled()) {
+            if (context.getPhaseManager().getCurrentPhase() == GamePhase.SWIPE) {
+                event.setCancelled(true);
+            }
+            return;
+        }
+
         // Handle SWIPE phase specially - always show holograms
         if (context.getPhaseManager().getCurrentPhase() == GamePhase.SWIPE) {
             // Cancel normal chat and show hologram instead

--- a/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/config/ConfigManager.java
@@ -131,6 +131,11 @@ public class ConfigManager {
         if (!config.contains("cosmetics.use-steve-skins")) {
             config.set("cosmetics.use-steve-skins", true);
         }
+
+        // Sign mode settings
+        if (!config.contains("sign-mode.enabled")) {
+            config.set("sign-mode.enabled", true);
+        }
     }
 
     /**
@@ -249,7 +254,7 @@ public class ConfigManager {
 
     /**
      * Gets the minimum number of players required to start a game.
-     * Validates and clamps to reasonable range (2-7).
+     * Validates and clamps to reasonable range (2-20).
      *
      * @return minimum number of players
      */
@@ -259,9 +264,9 @@ public class ConfigManager {
             plugin.getLogger().warning("Min players too low (" + min + "), using minimum 2");
             return 2;
         }
-        if (min > 7) {
-            plugin.getLogger().warning("Min players too high (" + min + "), using maximum 7");
-            return 7;
+        if (min > 20) {
+            plugin.getLogger().warning("Min players too high (" + min + "), using maximum 20");
+            return 20;
         }
         // Ensure min doesn't exceed max (read max directly to avoid recursion)
         int maxRaw = config.getInt("session.max-players", 7);
@@ -291,7 +296,7 @@ public class ConfigManager {
         }
         // Ensure max is at least equal to min (read min directly to avoid recursion)
         int minRaw = config.getInt("session.min-players", 2);
-        int min = Math.max(2, Math.min(minRaw, 7));
+        int min = Math.max(2, Math.min(minRaw, 20));
         if (max < min) {
             plugin.getLogger().warning("Max players (" + max + ") is less than min players (" + min + "), adjusting max to " + min);
             return Math.max(min, 2);
@@ -335,6 +340,18 @@ public class ConfigManager {
      */
     public boolean isUseSteveSkins() {
         return config.getBoolean("cosmetics.use-steve-skins", false);
+    }
+
+    /**
+     * Gets whether sign mode is enabled.
+     * When enabled, players receive a wooden axe and two stacks of oak signs at the start
+     * of the swipe phase and can use signs to chat instead of normal text chat.
+     * All signs placed during swipe phase are removed when discussion starts.
+     *
+     * @return true if sign mode is enabled
+     */
+    public boolean isSignModeEnabled() {
+        return config.getBoolean("sign-mode.enabled", true);
     }
     
     /**

--- a/src/main/java/com/ohacd/matchbox/game/cosmetic/SkinManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/cosmetic/SkinManager.java
@@ -1,11 +1,22 @@
 package com.ohacd.matchbox.game.cosmetic;
 
-import com.destroystokyo.paper.profile.PlayerProfile;
-import com.destroystokyo.paper.profile.ProfileProperty;
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.EnumWrappers;
+import com.comphenix.protocol.wrappers.PlayerInfoData;
+import com.comphenix.protocol.wrappers.WrappedGameProfile;
+import com.comphenix.protocol.wrappers.WrappedSignedProperty;
+import com.google.common.collect.Multimap;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
+import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -26,9 +37,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Applies temporary random skins to players while a game is active.
- * Skins are fetched asynchronously from Mojang's profile service via PlayerProfile#complete
- * and cached for reuse. Original player skins are restored when the game ends or the player leaves.
+ * Applies temporary skins during active games using ProtocolLib packet rewriting.
+ *
+ * This approach avoids mutating the server-side PlayerProfile and only rewrites
+ * player info packets seen by clients, which is more resilient across phase changes.
  */
 public class SkinManager {
     private static final List<String> DEFAULT_SKIN_NAMES = List.of(
@@ -49,22 +61,46 @@ public class SkinManager {
         .connectTimeout(Duration.ofSeconds(5))
         .build();
     private static final Duration PROFILE_TIMEOUT = Duration.ofSeconds(5);
-    private static final Pattern PROFILE_ID_PATTERN = Pattern.compile("\"id\"\\s*:\\s*\"([0-9a-fA-F]{32})\"");
-    // Signed Steve (classic) texture pulled from Mojang session servers.
+    private static final Pattern PROFILE_ID_PATTERN = Pattern.compile("\\\"id\\\"\\s*:\\s*\\\"([0-9a-fA-F]{32})\\\"");
     private static final SkinData DEFAULT_STEVE = new SkinData(
-        "e3RleHR1cmVzOntTS0lOOnt1cmw6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDE5MWM0OTRiZjA2ZTYzMjg0YWI5MDdmMDRiNmQ5YTFiNWU2MzlmYTUxNmMzOTQzMTA2ZWEzNmUwMWYwMWJkMCJ9fX0=",
-        "" // No signature for default steve skin
+        "ewogICJ0aW1lc3RhbXAiIDogMTc3NDUwMDQzMjk2OCwKICAicHJvZmlsZUlkIiA6ICJiMTM1MDRmMjMxOGI0OWNjYWFkZDcyYWVhYmMyNTQ1MCIsCiAgInByb2ZpbGVOYW1lIiA6ICJUeXBrZW4iLAogICJzaWduYXR1cmVSZXF1aXJlZCIgOiB0cnVlLAogICJ0ZXh0dXJlcyIgOiB7CiAgICAiU0tJTiIgOiB7CiAgICAgICJ1cmwiIDogImh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWE5YjQwMGRmZDUyOTUyYzM1Y2UzZmY1MzcwNTY1MWQ0MjVkMjMwYjBmOGM4M2YxNjg5ZTFkZTgyNzFjZDM1MiIKICAgIH0KICB9Cn0=",
+        "wYbFAH3ejP+MO1YNAoe8RlhwYc2v3G6oz4v4e2uH/YvENmqPqnKzerKhIVq69vyvndmLIJd5XHyiKJhuiYpeMwBtzo5D54nLiVdCGG+MXdkEmTyJtuna1CzIFnYnx8gT6JMK0wztgR6IFa/WwGQU4pfYI0+xXutmwqKqsKMUkrutalHkS5FUSovPTGDSKz66JDxpxSo8a9GVxNJIUrbUszg50GbuYURQ3l4D6vKR4IufH3Q4Z9oDUcD5f8EYI3EhNmfytUHRa51r0hmrNGDvFSYaix97PrPASgBDSy9m0xCNTR5Sno+TyYb+QyJfh1nT7MpGMtClHi3OzBT4vaQG9A8+vu+ISuYcwWvswcHisYCq+8AulaPfd//+oWjnZEDISwBvHq26jyOs4ct56qXTReRf0zgWELlJIs/YM/n8Jpgs1lEdXcBUZZPLsyAeanKL3GwApq9GTlPMAanihYeaWM5HeonxUPUZKD1Z4Xwd0gdB6VQHRCPVHtyN4/DHP4idQOdF62izUKrNXODNbHXnElEgpVmy8Zgawaval8vo9GkRRxXMPh4SQ88RlVnStQdQbSPAwnVSVOBlLlidy9tJA71a4ktQJTqlIEFciLhryOdyxhPI/UiKW1TRYOcMhfVCI8RprMTeisEeE1hsqZCgNRySva8XmmqxY2uvzvlnyy8="
     );
-    
 
     private final Plugin plugin;
     private final List<SkinData> cachedSkins = new CopyOnWriteArrayList<>();
     private final Map<UUID, SkinData> originalSkins = new ConcurrentHashMap<>();
     private final Map<UUID, SkinData> assignedSkins = new ConcurrentHashMap<>();
+    private final Set<UUID> discussionOriginalView = ConcurrentHashMap.newKeySet();
+    private final ProtocolManager protocolManager;
+    private final boolean packetMode;
+
     private volatile boolean preloading = false;
+    private volatile boolean loggedOfflineModeFallback = false;
 
     public SkinManager(Plugin plugin) {
         this.plugin = plugin;
+        ProtocolManager manager = null;
+        boolean available = false;
+
+        try {
+            if (Bukkit.getPluginManager().isPluginEnabled("ProtocolLib")) {
+                manager = ProtocolLibrary.getProtocolManager();
+                available = manager != null;
+            }
+        } catch (Throwable t) {
+            plugin.getLogger().warning("[SkinManager] ProtocolLib not available for packet skins: " + t.getMessage());
+        }
+
+        this.protocolManager = manager;
+        this.packetMode = available;
+
+        if (packetMode) {
+            registerPacketListener();
+            plugin.getLogger().info("[SkinManager] Using ProtocolLib packet-based skin overrides.");
+        } else {
+            plugin.getLogger().warning("[SkinManager] ProtocolLib unavailable. Falling back to direct profile skin updates.");
+        }
     }
 
     /**
@@ -76,13 +112,28 @@ public class SkinManager {
         }
         preloading = true;
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            for (String name : DEFAULT_SKIN_NAMES) {
-                fetchSkinByName(name).ifPresent(cachedSkins::add);
-            }
-            if (cachedSkins.isEmpty()) {
-                plugin.getLogger().warning("[SkinManager] Could not cache any random skins. Falling back to player defaults.");
-            } else {
-                plugin.getLogger().info("[SkinManager] Cached " + cachedSkins.size() + " random skins for upcoming games.");
+            try {
+                if (!Bukkit.getServer().getOnlineMode()) {
+                    if (!loggedOfflineModeFallback) {
+                        plugin.getLogger().info("[SkinManager] Server is in offline mode. Using Steve-only skin fallback.");
+                        loggedOfflineModeFallback = true;
+                    }
+                    cachedSkins.clear();
+                    ensureSteveFallbackCached();
+                    return;
+                }
+
+                for (String name : DEFAULT_SKIN_NAMES) {
+                    fetchSkinByName(name).ifPresent(cachedSkins::add);
+                }
+                if (cachedSkins.isEmpty()) {
+                    plugin.getLogger().warning("[SkinManager] Could not cache any random skins. Falling back to Steve-only skins.");
+                    ensureSteveFallbackCached();
+                } else {
+                    plugin.getLogger().info("[SkinManager] Cached " + cachedSkins.size() + " random skins for upcoming games.");
+                }
+            } finally {
+                preloading = false;
             }
         });
     }
@@ -100,14 +151,12 @@ public class SkinManager {
     }
 
     /**
-     * Applies Steve (default) skin to every player in the supplied collection.
-     * This removes all custom skin properties, giving players the default Minecraft skin.
+     * Applies Steve skin to every player in the supplied collection.
      */
     public void applySteveSkins(Collection<Player> players) {
         if (players == null || players.isEmpty()) {
             return;
         }
-        // Apply steve skin to all players to ensure consistency
         for (Player player : players) {
             if (player != null && player.isOnline()) {
                 applySteveSkin(player);
@@ -116,53 +165,47 @@ public class SkinManager {
     }
 
     /**
-     * Applies Steve (default) skin to a single player.
-     * This removes all custom skin properties, giving the player the default Minecraft skin.
+     * Applies Steve skin to a single player.
      */
     public void applySteveSkin(Player player) {
         if (player == null || !player.isOnline()) {
             return;
         }
+
         UUID playerId = player.getUniqueId();
-        if (!originalSkins.containsKey(playerId)) {
-            captureCurrentSkin(player).ifPresent(skin -> originalSkins.put(playerId, skin));
-        }
-        // Store Steve skin data as assigned skin so we can restore it after discussion
+        rememberOriginalIfNeeded(player);
         assignedSkins.put(playerId, DEFAULT_STEVE);
-        // Apply the Steve skin via shared setter - ensure it runs on main thread
-        if (Bukkit.isPrimaryThread()) {
-            setSkin(player, DEFAULT_STEVE);
-            refreshAppearance(player);
-        } else {
-            Bukkit.getScheduler().runTask(plugin, () -> {
-                if (player.isOnline()) {
-                    setSkin(player, DEFAULT_STEVE);
-                    refreshAppearance(player);
-                }
-            });
-        }
+        discussionOriginalView.remove(playerId);
+        setSkinDirect(player, DEFAULT_STEVE);
+        refreshAppearance(player);
     }
 
     /**
-     * Applies a random skin to the provided player. No-op if no cached skins exist.
+     * Applies a random skin to the provided player.
      */
     public void applyRandomSkin(Player player) {
         if (player == null || !player.isOnline()) {
             return;
         }
-        if (cachedSkins.isEmpty()) {
+        if (!Bukkit.getServer().getOnlineMode()) {
+            applySteveSkin(player);
             return;
         }
-        UUID playerId = player.getUniqueId();
-        if (!originalSkins.containsKey(playerId)) {
-            captureCurrentSkin(player).ifPresent(skin -> originalSkins.put(playerId, skin));
+        if (cachedSkins.isEmpty()) {
+            applySteveSkin(player);
+            return;
         }
+
+        UUID playerId = player.getUniqueId();
+        rememberOriginalIfNeeded(player);
         SkinData chosen = pickRandomSkin(playerId);
         if (chosen == null) {
             return;
         }
+
         assignedSkins.put(playerId, chosen);
-        setSkin(player, chosen);
+        discussionOriginalView.remove(playerId);
+        setSkinDirect(player, chosen);
         refreshAppearance(player);
     }
 
@@ -173,16 +216,19 @@ public class SkinManager {
         if (player == null) {
             return;
         }
+
         UUID playerId = player.getUniqueId();
         SkinData original = originalSkins.remove(playerId);
         assignedSkins.remove(playerId);
-        if (original == null) {
-            return;
-        }
+        discussionOriginalView.remove(playerId);
+
         if (!player.isOnline()) {
             return;
         }
-        setSkin(player, original);
+
+        if (original != null) {
+            setSkinDirect(player, original);
+        }
         refreshAppearance(player);
     }
 
@@ -193,6 +239,7 @@ public class SkinManager {
         if (playerIds == null || playerIds.isEmpty()) {
             return;
         }
+
         for (UUID uuid : new ArrayList<>(playerIds)) {
             Player player = Bukkit.getPlayer(uuid);
             if (player != null && player.isOnline()) {
@@ -200,49 +247,56 @@ public class SkinManager {
             } else {
                 originalSkins.remove(uuid);
                 assignedSkins.remove(uuid);
+                discussionOriginalView.remove(uuid);
             }
         }
     }
 
     /**
-     * Temporarily restores original skins for players during discussion phase.
-     * Does NOT remove assigned skins, so they can be restored later.
+     * Temporarily shows original skins during discussion, without losing assigned skins.
      */
     public void restoreOriginalSkinsForDiscussion(Collection<Player> players) {
         if (players == null || players.isEmpty()) {
             return;
         }
+
         for (Player player : players) {
             if (player == null || !player.isOnline()) {
                 continue;
             }
             UUID playerId = player.getUniqueId();
+            discussionOriginalView.add(playerId);
+
             SkinData original = originalSkins.get(playerId);
             if (original != null) {
-                setSkin(player, original);
-                refreshAppearance(player);
+                setSkinDirect(player, original);
             }
+
+            refreshAppearance(player);
         }
     }
 
     /**
-     * Restores assigned skins for players after discussion phase ends.
-     * Uses the assigned skins that were stored when skins were first applied.
+     * Re-applies assigned game skins after discussion ends.
      */
     public void restoreAssignedSkinsAfterDiscussion(Collection<Player> players) {
         if (players == null || players.isEmpty()) {
             return;
         }
+
         for (Player player : players) {
             if (player == null || !player.isOnline()) {
                 continue;
             }
             UUID playerId = player.getUniqueId();
+            discussionOriginalView.remove(playerId);
+
             SkinData assigned = assignedSkins.get(playerId);
             if (assigned != null) {
-                setSkin(player, assigned);
-                refreshAppearance(player);
+                setSkinDirect(player, assigned);
             }
+
+            refreshAppearance(player);
         }
     }
 
@@ -250,16 +304,176 @@ public class SkinManager {
         if (cachedSkins.isEmpty()) {
             return null;
         }
+
         SkinData currentlyAssigned = assignedSkins.get(playerId);
         SkinData candidate = cachedSkins.get(ThreadLocalRandom.current().nextInt(cachedSkins.size()));
-        // if the candidate matches the currently assigned skin, try once more for variety
         if (currentlyAssigned != null && candidate.equals(currentlyAssigned) && cachedSkins.size() > 1) {
             candidate = cachedSkins.get(ThreadLocalRandom.current().nextInt(cachedSkins.size()));
         }
         return candidate;
     }
 
-    private void setSkin(Player player, SkinData skinData) {
+    private void registerPacketListener() {
+        PacketType[] packetTypes = resolvePlayerInfoPacketTypes();
+        if (packetTypes.length == 0) {
+            plugin.getLogger().warning("[SkinManager] No supported player-info packet types found. Skin packet overrides disabled.");
+            return;
+        }
+
+        PacketAdapter adapter = new PacketAdapter(plugin, ListenerPriority.NORMAL, packetTypes) {
+            @Override
+            public void onPacketSending(PacketEvent event) {
+                if (event == null || event.getPacket() == null) {
+                    return;
+                }
+                try {
+                    rewritePlayerInfoPacket(event.getPacket());
+                } catch (Exception e) {
+                    plugin.getLogger().warning("[SkinManager] Failed to rewrite PLAYER_INFO packet: " + e.getMessage());
+                }
+            }
+        };
+        protocolManager.addPacketListener(adapter);
+        plugin.getLogger().info("[SkinManager] Listening for packet skin rewrites on " + packetTypes.length + " player-info packet type(s).");
+    }
+
+    private PacketType[] resolvePlayerInfoPacketTypes() {
+        List<PacketType> types = new ArrayList<>(2);
+
+        PacketType playerInfo = resolvePlayerInfoPacketType("PLAYER_INFO");
+        if (playerInfo != null) {
+            types.add(playerInfo);
+        }
+
+        PacketType playerInfoUpdate = resolvePlayerInfoPacketType("PLAYER_INFO_UPDATE");
+        if (playerInfoUpdate != null && !types.contains(playerInfoUpdate)) {
+            types.add(playerInfoUpdate);
+        }
+
+        return types.toArray(new PacketType[0]);
+    }
+
+    private PacketType resolvePlayerInfoPacketType(String fieldName) {
+        try {
+            Field field = PacketType.Play.Server.class.getField(fieldName);
+            Object value = field.get(null);
+            if (value instanceof PacketType packetType) {
+                return packetType;
+            }
+        } catch (NoSuchFieldException ignored) {
+            // Packet not present on this ProtocolLib version.
+        } catch (Exception e) {
+            plugin.getLogger().warning("[SkinManager] Failed to resolve packet type '" + fieldName + "': " + e.getMessage());
+        }
+        return null;
+    }
+
+    private void rewritePlayerInfoPacket(PacketContainer packet) {
+        if (!isAddPlayerAction(packet)) {
+            return;
+        }
+
+        if (packet.getPlayerInfoDataLists().size() <= 0) {
+            return;
+        }
+
+        List<PlayerInfoData> entries = packet.getPlayerInfoDataLists().read(0);
+        if (entries == null || entries.isEmpty()) {
+            return;
+        }
+
+        boolean changed = false;
+        List<PlayerInfoData> rewritten = new ArrayList<>(entries.size());
+
+        for (PlayerInfoData entry : entries) {
+            PlayerInfoData updated = rewriteEntry(entry);
+            rewritten.add(updated);
+            if (updated != entry) {
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            packet.getPlayerInfoDataLists().write(0, rewritten);
+        }
+    }
+
+    private boolean isAddPlayerAction(PacketContainer packet) {
+        if (packet.getPlayerInfoActions().size() > 0) {
+            Set<EnumWrappers.PlayerInfoAction> actions = packet.getPlayerInfoActions().read(0);
+            return actions != null && actions.contains(EnumWrappers.PlayerInfoAction.ADD_PLAYER);
+        }
+        if (packet.getPlayerInfoAction().size() > 0) {
+            EnumWrappers.PlayerInfoAction action = packet.getPlayerInfoAction().read(0);
+            return action == EnumWrappers.PlayerInfoAction.ADD_PLAYER;
+        }
+        return false;
+    }
+
+    private PlayerInfoData rewriteEntry(PlayerInfoData entry) {
+        if (entry == null) {
+            return entry;
+        }
+
+        WrappedGameProfile sourceProfile = entry.getProfile();
+        if (sourceProfile == null) {
+            return entry;
+        }
+
+        UUID profileId = entry.getProfileId();
+        if (profileId == null) {
+            profileId = sourceProfile.getUUID();
+        }
+        if (profileId == null || discussionOriginalView.contains(profileId)) {
+            return entry;
+        }
+
+        SkinData skinData = assignedSkins.get(profileId);
+        if (skinData == null) {
+            return entry;
+        }
+
+        WrappedGameProfile updatedProfile = cloneWithSkin(sourceProfile, skinData);
+        return new PlayerInfoData(
+            profileId,
+            entry.getLatency(),
+            entry.isListed(),
+            entry.getGameMode(),
+            updatedProfile,
+            entry.getDisplayName(),
+            entry.isShowHat(),
+            entry.getListOrder(),
+            entry.getRemoteChatSessionData()
+        );
+    }
+
+    private WrappedGameProfile cloneWithSkin(WrappedGameProfile source, SkinData skinData) {
+        WrappedGameProfile clone = new WrappedGameProfile(source.getUUID(), source.getName());
+        Multimap<String, WrappedSignedProperty> sourceProperties = source.getProperties();
+        Multimap<String, WrappedSignedProperty> cloneProperties = clone.getProperties();
+
+        for (Map.Entry<String, WrappedSignedProperty> property : sourceProperties.entries()) {
+            if ("textures".equalsIgnoreCase(property.getKey())) {
+                continue;
+            }
+            cloneProperties.put(property.getKey(), property.getValue());
+        }
+
+        if (skinData.value() != null && !skinData.value().isBlank()) {
+            cloneProperties.put(
+                "textures",
+                new WrappedSignedProperty("textures", skinData.value(), skinData.signature() != null ? skinData.signature() : "")
+            );
+        }
+
+        return clone;
+    }
+
+    private void rememberOriginalIfNeeded(Player player) {
+        originalSkins.computeIfAbsent(player.getUniqueId(), id -> captureCurrentSkin(player).orElse(new SkinData("", "")));
+    }
+
+    private void setSkinDirect(Player player, SkinData skinData) {
         try {
             if (skinData == null) {
                 plugin.getLogger().warning("[SkinManager] Cannot apply null skin data to " + player.getName());
@@ -268,17 +482,18 @@ public class SkinManager {
             if (player == null || !player.isOnline()) {
                 return;
             }
-            PlayerProfile profile = Bukkit.createProfile(player.getUniqueId(), player.getName());
+
+            com.destroystokyo.paper.profile.PlayerProfile profile = Bukkit.createProfile(player.getUniqueId(), player.getName());
             if (profile == null) {
                 plugin.getLogger().warning("[SkinManager] Failed to create profile for " + player.getName());
                 return;
             }
-            Collection<ProfileProperty> properties = profile.getProperties();
+
+            Collection<com.destroystokyo.paper.profile.ProfileProperty> properties = profile.getProperties();
             properties.clear();
-            // If value is blank, we intentionally leave properties empty to force the default Steve skin
             if (skinData.value() != null && !skinData.value().isBlank()) {
                 String signature = skinData.signature() != null ? skinData.signature() : "";
-                profile.setProperty(new ProfileProperty("textures", skinData.value(), signature));
+                profile.setProperty(new com.destroystokyo.paper.profile.ProfileProperty("textures", skinData.value(), signature));
             }
             player.setPlayerProfile(profile);
         } catch (Exception e) {
@@ -287,9 +502,10 @@ public class SkinManager {
     }
 
     private void refreshAppearance(Player player) {
-        if (!player.isOnline()) {
+        if (player == null || !player.isOnline()) {
             return;
         }
+
         Runnable task = () -> {
             for (Player viewer : Bukkit.getOnlinePlayers()) {
                 if (viewer.equals(player)) {
@@ -299,6 +515,7 @@ public class SkinManager {
                 viewer.showPlayer(plugin, player);
             }
         };
+
         if (Bukkit.isPrimaryThread()) {
             task.run();
         } else {
@@ -308,11 +525,11 @@ public class SkinManager {
 
     private Optional<SkinData> captureCurrentSkin(Player player) {
         try {
-            PlayerProfile profile = player.getPlayerProfile();
+            com.destroystokyo.paper.profile.PlayerProfile profile = player.getPlayerProfile();
             if (profile == null) {
                 return Optional.empty();
             }
-            for (ProfileProperty property : profile.getProperties()) {
+            for (com.destroystokyo.paper.profile.ProfileProperty property : profile.getProperties()) {
                 if ("textures".equalsIgnoreCase(property.getName())) {
                     String value = property.getValue();
                     String signature = property.getSignature();
@@ -329,17 +546,23 @@ public class SkinManager {
 
     private Optional<SkinData> fetchSkinByName(String skinName) {
         try {
+            if (!Bukkit.getServer().getOnlineMode()) {
+                return Optional.empty();
+            }
+
             Optional<UUID> onlineUuid = resolveOnlineUuid(skinName);
             if (onlineUuid.isEmpty()) {
                 plugin.getLogger().warning("[SkinManager] Unable to resolve UUID for '" + skinName + "'. Skipping.");
                 return Optional.empty();
             }
-            PlayerProfile profile = Bukkit.createProfile(onlineUuid.get(), skinName);
+
+            com.destroystokyo.paper.profile.PlayerProfile profile = Bukkit.createProfile(onlineUuid.get(), skinName);
             if (!profile.complete(true)) {
                 plugin.getLogger().warning("[SkinManager] Mojang session server rejected skin '" + skinName + "'.");
                 return Optional.empty();
             }
-            for (ProfileProperty property : profile.getProperties()) {
+
+            for (com.destroystokyo.paper.profile.ProfileProperty property : profile.getProperties()) {
                 if ("textures".equalsIgnoreCase(property.getName())) {
                     return Optional.of(new SkinData(property.getValue(), property.getSignature()));
                 }
@@ -349,6 +572,12 @@ public class SkinManager {
             plugin.getLogger().warning("[SkinManager] Failed to fetch skin '" + skinName + "': " + e.getMessage());
         }
         return Optional.empty();
+    }
+
+    private void ensureSteveFallbackCached() {
+        if (!cachedSkins.contains(DEFAULT_STEVE)) {
+            cachedSkins.add(DEFAULT_STEVE);
+        }
     }
 
     private Optional<UUID> resolveOnlineUuid(String skinName) {
@@ -362,6 +591,7 @@ public class SkinManager {
             if (response.statusCode() != 200 || response.body() == null || response.body().isBlank()) {
                 return Optional.empty();
             }
+
             Matcher matcher = PROFILE_ID_PATTERN.matcher(response.body());
             if (matcher.find()) {
                 String rawId = matcher.group(1);
@@ -386,4 +616,3 @@ public class SkinManager {
 
     private record SkinData(String value, String signature) {}
 }
-

--- a/src/main/java/com/ohacd/matchbox/game/hologram/HologramManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/hologram/HologramManager.java
@@ -38,6 +38,14 @@ public class HologramManager {
     }
 
     public void showTextAbove(Player player, String text, int ticks) {
+        if (player == null || !player.isOnline()) {
+            return;
+        }
+
+        if (!plugin.isEnabled()) {
+            return;
+        }
+
         // Run on main thread
         plugin.getServer().getScheduler().runTask(plugin, () -> {
             UUID id = player.getUniqueId();
@@ -94,7 +102,7 @@ public class HologramManager {
     }
 
     public void clearAll() {
-        plugin.getServer().getScheduler().runTask(plugin, () -> {
+        Runnable clearTask = () -> {
             for (HologramEntry entry : active.values()) {
                 try {
                     if (entry.task != null) entry.task.cancel();
@@ -104,6 +112,19 @@ public class HologramManager {
                 } catch (Exception ignored) {}
             }
             active.clear();
-        });
+        };
+
+        if (plugin.getServer().isPrimaryThread()) {
+            clearTask.run();
+            return;
+        }
+
+        if (plugin.isEnabled()) {
+            plugin.getServer().getScheduler().runTask(plugin, clearTask);
+            return;
+        }
+
+        // Plugin is disabled and this is async; best-effort cleanup without touching entities off-thread.
+        active.clear();
     }
 }

--- a/src/main/java/com/ohacd/matchbox/game/lifecycle/GameLifecycleManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/lifecycle/GameLifecycleManager.java
@@ -15,8 +15,10 @@ import org.bukkit.plugin.Plugin;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -72,7 +74,8 @@ public class GameLifecycleManager {
         // Store session name
         gameState.setActiveSessionName(sessionName);
         
-        // Backup player states before game starts
+        // Backup player states before game starts; build a filtered list excluding backup failures
+        Set<UUID> failedBackups = new HashSet<>();
         for (Player player : players) {
             if (player == null || !player.isOnline()) {
                 plugin.getLogger().warning("Skipping null or offline player during backup");
@@ -83,29 +86,44 @@ public class GameLifecycleManager {
                 // Set gamemode to adventure mode for gameplay
                 player.setGameMode(org.bukkit.GameMode.ADVENTURE);
             } catch (Exception e) {
-                plugin.getLogger().severe("Failed to backup player " + (player != null ? player.getName() : "null") + ": " + e.getMessage());
+                plugin.getLogger().severe("Failed to backup player " + player.getName() + ": " + e.getMessage());
                 e.printStackTrace();
+                failedBackups.add(player.getUniqueId());
             }
         }
-        
+
+        // Build effective player list, excluding those whose backups failed
+        List<Player> playerList = new ArrayList<>();
+        for (Player player : players) {
+            if (player != null && player.isOnline() && !failedBackups.contains(player.getUniqueId())) {
+                playerList.add(player);
+            }
+        }
+
+        if (!failedBackups.isEmpty()) {
+            plugin.getLogger().warning("Excluding " + failedBackups.size() + " player(s) with failed backups from session '" + sessionName + "'");
+        }
+
+        if (playerList.isEmpty()) {
+            plugin.getLogger().severe("No valid players remain after backup failures for session '" + sessionName + "' — aborting game start");
+            return;
+        }
+
         // Add players to alive set
-        gameState.addAlivePlayers(players);
-        
-        // Assign roles (only once per game, not per round)
-        List<Player> playerList = new ArrayList<>(players);
+        gameState.addAlivePlayers(playerList);
         context.getRoleAssigner().assignRoles(playerList);
         
         // Validate state after initialization
         if (!gameState.validateState()) {
             plugin.getLogger().severe("Game state invalid after initialization: " + gameState.getDebugInfo());
-            plugin.getLogger().severe("Players: " + players.size() + ", Roles assigned: " + gameState.getAllParticipatingPlayerIds().size());
+            plugin.getLogger().severe("Players: " + playerList.size() + ", Roles assigned: " + gameState.getAllParticipatingPlayerIds().size());
             // Attempt cleanup
             gameState.clearGameState();
             context.getPhaseManager().reset();
             return;
         }
         
-        plugin.getLogger().info("Game started successfully for session '" + sessionName + "' with " + players.size() + " players. Roles: " + 
+        plugin.getLogger().info("Game started successfully for session '" + sessionName + "' with " + playerList.size() + " players. Roles: " + 
             gameState.getAllParticipatingPlayerIds().stream()
                 .map(id -> {
                     Role role = gameState.getRole(id);
@@ -173,7 +191,7 @@ public class GameLifecycleManager {
         // Clear per-round state (swipes, cures, votes) but keep roles and players
         gameState.clearRoundState();
         voteManager.clearVotes();
-        inventoryManager.resetArrowUsage();
+        inventoryManager.resetArrowUsage(sessionName);
         
         // Clear all inventories for all alive players before new round
         if (alivePlayers != null) {

--- a/src/main/java/com/ohacd/matchbox/game/nick/NickManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/nick/NickManager.java
@@ -1,0 +1,202 @@
+package com.ohacd.matchbox.game.nick;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+/**
+ * Manages Matchbox player nicks.
+ *
+ * <p>Nicks are stored persistently in {@code plugins/Matchbox/nicks.yml} (keyed by UUID)
+ * and are applied only when a player enters an active game session.  They affect:
+ * <ul>
+ *   <li>Chat display name ({@link Player#setDisplayName})</li>
+ *   <li>Tab-list name ({@link Player#setPlayerListName})</li>
+ *   <li>Above-head custom name ({@link Player#customName} + {@link Player#setCustomNameVisible})</li>
+ * </ul>
+ * All three are restored to the real username when the session ends.
+ */
+public final class NickManager {
+
+    // --- Result enum ---
+
+    public enum NickResult {
+        SUCCESS, TOO_SHORT, TOO_LONG, INVALID_CHARS
+    }
+
+    // --- Constants ---
+
+    private static final int MIN_LEN = 3;
+    private static final int MAX_LEN = 16;
+    /** Allowed characters for non-admin nicks. */
+    private static final Pattern SAFE = Pattern.compile("^[a-zA-Z0-9_\\-]+$");
+
+    // --- State ---
+
+    private final Plugin plugin;
+    private final Map<UUID, String> nicks = new ConcurrentHashMap<>();
+    private File nickFile;
+    private YamlConfiguration nickConfig;
+
+    // --- Constructor ---
+
+    public NickManager(Plugin plugin) {
+        this.plugin = plugin;
+        load();
+    }
+
+    // =========================================================
+    // Persistence
+    // =========================================================
+
+    private void load() {
+        if (!plugin.getDataFolder().exists()) {
+            plugin.getDataFolder().mkdirs();
+        }
+        nickFile = new File(plugin.getDataFolder(), "nicks.yml");
+        nickConfig = YamlConfiguration.loadConfiguration(nickFile);
+
+        int loaded = 0;
+        for (String key : nickConfig.getKeys(false)) {
+            try {
+                UUID uuid = UUID.fromString(key);
+                String nick = nickConfig.getString(key);
+                if (nick != null && !nick.isBlank()) {
+                    nicks.put(uuid, nick);
+                    loaded++;
+                }
+            } catch (IllegalArgumentException ignored) {
+                // skip malformed keys
+            }
+        }
+        plugin.getLogger().info("[NickManager] Loaded " + loaded + " nicks.");
+    }
+
+    private void save() {
+        for (Map.Entry<UUID, String> entry : nicks.entrySet()) {
+            nickConfig.set(entry.getKey().toString(), entry.getValue());
+        }
+        try {
+            nickConfig.save(nickFile);
+        } catch (IOException e) {
+            plugin.getLogger().warning("[NickManager] Failed to save nicks.yml: " + e.getMessage());
+        }
+    }
+
+    // =========================================================
+    // Core API
+    // =========================================================
+
+    /**
+     * Stores and persists a nick for the given player.
+     *
+     * @param uuid    target player UUID
+     * @param nick    desired nick string (may contain §-colour codes if admin)
+     * @param isAdmin whether the caller holds {@code matchbox.admin} — allows colour codes
+     * @return the validation result; only {@link NickResult#SUCCESS} means the nick was saved
+     */
+    public NickResult setNick(UUID uuid, String nick, boolean isAdmin) {
+        // Strip colour codes for length/char validation
+        String stripped = nick.replaceAll("§[0-9a-fA-Fk-orK-OR]", "");
+
+        if (stripped.length() < MIN_LEN) return NickResult.TOO_SHORT;
+        if (stripped.length() > MAX_LEN) return NickResult.TOO_LONG;
+        if (!SAFE.matcher(stripped).matches()) return NickResult.INVALID_CHARS;
+
+        // Non-admins may not include colour codes
+        if (!isAdmin && !nick.equals(stripped)) return NickResult.INVALID_CHARS;
+
+        nicks.put(uuid, nick);
+        nickConfig.set(uuid.toString(), nick);
+        save();
+        return NickResult.SUCCESS;
+    }
+
+    /**
+     * Removes a stored nick and persists the change.
+     */
+    public void removeNick(UUID uuid) {
+        nicks.remove(uuid);
+        nickConfig.set(uuid.toString(), null);
+        save();
+    }
+
+    /**
+     * Returns the stored nick for {@code uuid}, or {@code null} if none is set.
+     */
+    public String getNick(UUID uuid) {
+        return nicks.get(uuid);
+    }
+
+    // =========================================================
+    // Session helpers
+    // =========================================================
+
+    /**
+     * Builds the set of lower-case nicks currently stored for all players in a session.
+     * Used to detect collisions before applying nicks at game-start.
+     */
+    public Set<String> getTakenNicksInSession(Collection<UUID> sessionPlayerIds) {
+        Set<String> taken = new HashSet<>();
+        for (UUID id : sessionPlayerIds) {
+            String nick = nicks.get(id);
+            if (nick != null) taken.add(nick.toLowerCase());
+        }
+        return taken;
+    }
+
+    // =========================================================
+    // Apply / Restore
+    // =========================================================
+
+    /**
+     * Applies the player's stored nick if it is not already taken by another player
+     * in the same session.
+     *
+     * <p>Sets the display name, tab-list name, and above-head custom name.
+     * The above-head custom name is only visible because {@link com.ohacd.matchbox.game.utils.Managers.NameTagManager}
+     * hides the real username via a scoreboard team during the game.
+     *
+     * @param player     the player to nick
+     * @param takenLower lower-case nicks already active in the session (must NOT include this player's own nick)
+     * @return {@code true} if the nick was applied; {@code false} on collision or no nick stored
+     */
+    public boolean applyNick(Player player, Set<String> takenLower) {
+        String nick = nicks.get(player.getUniqueId());
+        if (nick == null) return false;
+        if (takenLower.contains(nick.toLowerCase())) return false;
+
+        player.setDisplayName(nick);
+        player.setPlayerListName(nick);
+
+        // Above-head custom name — visible while the real nametag is hidden by the scoreboard team
+        Component component = LegacyComponentSerializer.legacySection().deserialize(nick);
+        player.customName(component);
+        player.setCustomNameVisible(true);
+
+        return true;
+    }
+
+    /**
+     * Resets the player's display name, tab-list name, and above-head custom name
+     * back to their real username.
+     */
+    public void restoreNick(Player player) {
+        player.setDisplayName(player.getName());
+        player.setPlayerListName(player.getName());
+        player.customName(null);
+        player.setCustomNameVisible(false);
+    }
+}

--- a/src/main/java/com/ohacd/matchbox/game/nick/RandomNickGenerator.java
+++ b/src/main/java/com/ohacd/matchbox/game/nick/RandomNickGenerator.java
@@ -1,0 +1,137 @@
+package com.ohacd.matchbox.game.nick;
+
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Generates realistic-looking random usernames for the nicking system.
+ *
+ * <p>Format is one of several styles modelled on real Minecraft IGNs:
+ * <ul>
+ *   <li>{@code FrostWolf}       — PascalCase, no separator  (most common)</li>
+ *   <li>{@code frost_wolf}      — all-lowercase with underscore</li>
+ *   <li>{@code Frost_Wolf}      — title-case with underscore</li>
+ *   <li>{@code frostWolf}       — camelCase, first part lowercase</li>
+ *   <li>{@code FROST_wolf}      — uppercase adjective, lowercase noun, underscore</li>
+ *   <li>{@code frost_WOLF}      — lowercase adjective, uppercase noun, underscore</li>
+
+ * </ul>
+ * A numeric suffix (2 digits) is appended on collision, matching the common
+ * {@code FrostWolf42} IGN pattern.
+ */
+public final class RandomNickGenerator {
+
+    private static final Random RANDOM = new Random();
+
+    private static final String[] ADJECTIVES = {
+        "shadow", "ember", "frost", "stone", "void", "iron", "crimson", "silent",
+        "swift", "dark", "storm", "bright", "hollow", "silver", "grim", "ashen",
+        "scarlet", "obsidian", "molten", "crystal", "jade", "copper", "blazing",
+        "frozen", "wicked", "noble", "phantom", "rusted", "gilded", "lunar",
+        "solar", "cursed", "bitter", "wild", "sage", "dusk", "dawn", "arcane",
+        "rogue", "stealth", "cyber", "neon", "blood", "toxic", "electric",
+        "cosmic", "brutal", "acid", "hyper", "static"
+    };
+
+    private static final String[] NOUNS = {
+        "blade", "wolf", "raven", "arrow", "fox", "spark", "viper", "falcon",
+        "lynx", "cobra", "hawk", "claw", "fang", "wisp", "shade", "wraith",
+        "specter", "crow", "pyre", "coil", "tide", "gust", "pulse", "shard",
+        "vault", "drift", "flare", "strike", "surge", "rift", "crest", "dagger",
+        "shield", "thorn", "dust", "veil", "skull", "forge", "bolt", "rider",
+        "ghost", "hunter", "sniper", "reaper", "knight", "striker", "agent",
+        "phantom", "ranger", "warden"
+    };
+
+    // ---------------------------------------------------------------------------
+    // Style enum
+    // ---------------------------------------------------------------------------
+
+    private enum Style {
+        /** FrostWolf */
+        PASCAL_NO_SEP,
+        /** frost_wolf */
+        LOWER_UNDERSCORE,
+        /** Frost_Wolf */
+        TITLE_UNDERSCORE,
+        /** frostWolf */
+        CAMEL,
+        /** FROST_wolf */
+        UPPER_ADJ_LOWER_NOUN_UNDERSCORE,
+        /** frost_WOLF */
+        LOWER_ADJ_UPPER_NOUN_UNDERSCORE;
+
+        // Weights: PascalCase is the most common real-IGN pattern
+        private static final Style[] WEIGHTED = {
+            PASCAL_NO_SEP, PASCAL_NO_SEP, PASCAL_NO_SEP,
+            LOWER_UNDERSCORE,
+            TITLE_UNDERSCORE, TITLE_UNDERSCORE,
+            CAMEL, CAMEL,
+            UPPER_ADJ_LOWER_NOUN_UNDERSCORE,
+            LOWER_ADJ_UPPER_NOUN_UNDERSCORE
+        };
+
+        static Style random(Random rng) {
+            return WEIGHTED[rng.nextInt(WEIGHTED.length)];
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Public API
+    // ---------------------------------------------------------------------------
+
+    private RandomNickGenerator() {}
+
+    /**
+     * Generates a random username without collision awareness.
+     */
+    public static String generate() {
+        String adj  = ADJECTIVES[RANDOM.nextInt(ADJECTIVES.length)];
+        String noun = NOUNS[RANDOM.nextInt(NOUNS.length)];
+        return applyStyle(adj, noun, Style.random(RANDOM));
+    }
+
+    /**
+     * Generates a username not present in {@code takenLower} (lower-case comparison).
+     * Appends a numeric suffix on collision; guaranteed to return a value.
+     *
+     * @param takenLower lower-case set of nicks already in use
+     * @return a unique nick candidate
+     */
+    public static String generateUnique(Set<String> takenLower) {
+        for (int attempt = 0; attempt < 12; attempt++) {
+            String candidate = generate();
+            if (!takenLower.contains(candidate.toLowerCase())) {
+                return candidate;
+            }
+            // Numeric suffix — matches real IGN patterns like FrostWolf42
+            String suffixed = candidate + (10 + RANDOM.nextInt(90));
+            if (!takenLower.contains(suffixed.toLowerCase())) {
+                return suffixed;
+            }
+        }
+        // Guaranteed-unique fallback
+        return "Player" + (1000 + RANDOM.nextInt(9000));
+    }
+
+    // ---------------------------------------------------------------------------
+    // Internal helpers
+    // ---------------------------------------------------------------------------
+
+    private static String applyStyle(String adj, String noun, Style style) {
+        return switch (style) {
+            case PASCAL_NO_SEP                   -> cap(adj) + cap(noun);
+            case LOWER_UNDERSCORE                -> adj + "_" + noun;
+            case TITLE_UNDERSCORE                -> cap(adj) + "_" + cap(noun);
+            case CAMEL                           -> adj + cap(noun);
+            case UPPER_ADJ_LOWER_NOUN_UNDERSCORE -> adj.toUpperCase() + "_" + noun;
+            case LOWER_ADJ_UPPER_NOUN_UNDERSCORE -> adj + "_" + noun.toUpperCase();
+        };
+    }
+
+    /** Capitalises only the first character of a lower-case word. */
+    private static String cap(String word) {
+        if (word == null || word.isEmpty()) return word;
+        return Character.toUpperCase(word.charAt(0)) + word.substring(1);
+    }
+}

--- a/src/main/java/com/ohacd/matchbox/game/phase/VotingPhaseHandler.java
+++ b/src/main/java/com/ohacd/matchbox/game/phase/VotingPhaseHandler.java
@@ -93,7 +93,7 @@ public class VotingPhaseHandler {
                 player.sendMessage("§e§lHow to Vote:");
                 player.sendMessage("§7- Right-click a voting paper in your inventory");
                 player.sendMessage("§7- Left-click a voting paper in your inventory");
-                player.sendMessage("§7- You can choose to not vote");
+                player.sendMessage("§e§l- You can choose to not vote");
                 if (requiredVotes > 0 && alivePlayerCount > 0) {
                     player.sendMessage("§7- Threshold: §e" + requiredVotes + "/" + alivePlayerCount + " §7votes required to eliminate a player");
                     player.sendMessage("§7- If threshold isn't met, no elimination will occur");

--- a/src/main/java/com/ohacd/matchbox/game/sign/SignModeListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/sign/SignModeListener.java
@@ -1,0 +1,182 @@
+package com.ohacd.matchbox.game.sign;
+
+import com.ohacd.matchbox.game.GameManager;
+import com.ohacd.matchbox.game.SessionGameContext;
+import com.ohacd.matchbox.game.utils.GamePhase;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+
+import java.util.UUID;
+
+/**
+ * Handles sign-mode gameplay events:
+ *
+ * <ul>
+ *   <li>{@link BlockPlaceEvent} — tracks every sign placed by an in-game player.</li>
+ *   <li>{@link BlockBreakEvent} — allows owners to break their own tracked signs with the
+ *       sign-mode axe; prevents all other player breaks; cleans up the tracking entry on
+ *       non-player destruction (pistons, explosions, etc.).</li>
+ * </ul>
+ *
+ * <p>Sign placement is only permitted during the SWIPE phase. Players read signs directly
+ * in the world; no chat broadcast is performed.</p>
+ */
+public class SignModeListener implements Listener {
+
+    private final GameManager gameManager;
+    private final SignModeManager signModeManager;
+
+    public SignModeListener(GameManager gameManager, SignModeManager signModeManager) {
+        if (gameManager == null || signModeManager == null) {
+            throw new IllegalArgumentException("GameManager and SignModeManager cannot be null");
+        }
+        this.gameManager = gameManager;
+        this.signModeManager = signModeManager;
+    }
+
+    // -------------------------------------------------------------------------
+    // Block placement — track sign positions
+    // -------------------------------------------------------------------------
+
+    /**
+     * Tracks a sign placed by an in-game player during the SWIPE phase.
+     *
+     * <p>Runs at LOW priority so it executes before any NORMAL/HIGH-priority
+     * cancellations (but after LOWEST, which the adventure-mode CanPlaceOn
+     * check uses).  If the placement has already been cancelled upstream we
+     * skip tracking.</p>
+     */
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onBlockPlace(BlockPlaceEvent event) {
+        Player player = event.getPlayer();
+        if (player == null) return;
+
+        Block placed = event.getBlockPlaced();
+        if (placed == null || !placed.getType().name().contains("SIGN")) return;
+
+        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
+        if (context == null || !context.getGameState().isGameActive()) return;
+
+        // Only track during SWIPE phase
+        if (context.getPhaseManager().getCurrentPhase() != GamePhase.SWIPE) {
+            // Cancel the placement outside of SWIPE phase as a safety measure
+            event.setCancelled(true);
+            return;
+        }
+
+        // Only track if sign mode is enabled for this session
+        if (!gameManager.isSignModeEnabled()) return;
+
+        // Only count players with sign-mode sign items (not random signs from outside)
+        if (!signModeManager.isSignModeItem(event.getItemInHand())) return;
+
+        String sessionName = context.getSessionName();
+        UUID placerId = player.getUniqueId();
+
+        signModeManager.registerSignPlacement(sessionName, placed.getLocation(), placerId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Block break — protect tracked signs
+    // -------------------------------------------------------------------------
+
+    /**
+     * Handles sign breaking during an active game.
+     *
+     * <ul>
+     *   <li>Players may break their own tracked signs with the sign-mode axe during SWIPE phase.</li>
+     *   <li>Players cannot break signs placed by other players.</li>
+     *   <li>Non-player break causes (pistons, explosions) silently remove the entry from tracking.</li>
+     * </ul>
+     *
+     * <p>Runs at HIGHEST priority to ensure the cancellation takes effect
+     * before other listeners process the event.</p>
+     */
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        Block block = event.getBlock();
+        if (block == null) return;
+
+        if (!block.getType().name().contains("SIGN")) return;
+
+        // Find which session (if any) this sign belongs to
+        String sessionName = findSessionForSign(block);
+        if (sessionName == null) return;
+
+        if (player != null) {
+            SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
+
+            // Allow the owner to break their own sign with the axe during SWIPE phase
+            if (context != null
+                    && context.getGameState().isGameActive()
+                    && context.getPhaseManager().getCurrentPhase() == GamePhase.SWIPE
+                    && gameManager.isSignModeEnabled()
+                    && isHoldingSignAxe(player)
+                    && player.getUniqueId().equals(signModeManager.getSignPlacer(sessionName, block.getLocation()))) {
+                // Force server-side removal and broadcast block update to avoid client desync in adventure mode.
+                signModeManager.removeSignTracking(sessionName, block.getLocation());
+                removeSignBlockForEveryone(block);
+                event.setCancelled(true);
+                return;
+            }
+
+            // All other player break attempts on tracked signs are blocked
+            event.setCancelled(true);
+            return;
+        }
+
+        // Non-player break (piston, explosion, etc.) — remove from tracking and make sure clients see air.
+        signModeManager.removeSignTracking(sessionName, block.getLocation());
+        removeSignBlockForEveryone(block);
+        event.setCancelled(true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Searches all active session contexts to find whether the given block's
+     * location is tracked as a sign-mode sign.  Returns the session name or
+     * {@code null} if not found.
+     */
+    private String findSessionForSign(Block block) {
+        // We need to check all sessions — gameManager exposes active session names
+        for (String sName : gameManager.getActiveSessionNames()) {
+            if (signModeManager.isTrackedSign(sName, block.getLocation())) {
+                return sName;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if the player is holding the sign-mode wooden axe in their main hand.
+     */
+    private boolean isHoldingSignAxe(Player player) {
+        ItemStack held = player.getInventory().getItemInMainHand();
+        if (held == null || held.getType() != Material.WOODEN_AXE) return false;
+        return signModeManager.isSignModeItem(held);
+    }
+
+    private void removeSignBlockForEveryone(Block block) {
+        if (block == null) return;
+
+        block.setType(Material.AIR, false);
+        if (block.getWorld() == null) return;
+
+        for (Player online : Bukkit.getOnlinePlayers()) {
+            online.sendBlockChange(block.getLocation(), Material.AIR.createBlockData());
+        }
+    }
+}

--- a/src/main/java/com/ohacd/matchbox/game/sign/SignModeManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/sign/SignModeManager.java
@@ -1,0 +1,341 @@
+package com.ohacd.matchbox.game.sign;
+
+import io.papermc.paper.block.BlockPredicate;
+import io.papermc.paper.datacomponent.DataComponentTypes;
+import io.papermc.paper.datacomponent.item.ItemAdventurePredicate;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.set.RegistrySet;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.block.BlockType;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages sign-mode items and per-session sign placement tracking.
+ *
+ * <p>When sign mode is enabled in config, players receive an axe and two stacks
+ * of oak signs during the swipe phase. Placed signs are tracked per session and
+ * automatically removed from the world when discussion starts.</p>
+ */
+public class SignModeManager {
+
+    /** Hotbar slot for the wooden axe. */
+    public static final int SIGN_AXE_SLOT = 0;
+    /** Hotbar slot for the first sign stack. */
+    public static final int SIGN_STACK_1_SLOT = 1;
+    /** Hotbar slot for the second sign stack. */
+    public static final int SIGN_STACK_2_SLOT = 2;
+
+    private static final int SIGN_STACK_SIZE = 16;
+
+    private final Plugin plugin;
+
+    /**
+     * PDC key used to mark items that belong to sign mode so they can be
+     * identified reliably without relying on display names.
+     */
+    private final NamespacedKey signModeItemKey;
+
+    /**
+     * Per-session tracking: sessionName → (block location → UUID of the player who placed it).
+     * ConcurrentHashMap is used to allow safe access from multiple threads (e.g. async events).
+     */
+    private final Map<String, Map<Location, UUID>> sessionSigns = new ConcurrentHashMap<>();
+
+    public SignModeManager(Plugin plugin) {
+        if (plugin == null) {
+            throw new IllegalArgumentException("Plugin cannot be null");
+        }
+        this.plugin = plugin;
+        this.signModeItemKey = new NamespacedKey(plugin, "sign-mode-item");
+    }
+
+    // -------------------------------------------------------------------------
+    // Item creation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates the wooden axe given to each player in sign mode.
+     * The item is marked with a PDC tag and set unbreakable so the existing
+     * {@link com.ohacd.matchbox.game.utils.listeners.GameItemProtectionListener}
+     * will prevent players from dropping or moving it.
+     */
+    public ItemStack createSignAxe() {
+        ItemStack axe = new ItemStack(Material.WOODEN_AXE);
+        ItemMeta meta = axe.getItemMeta();
+        if (meta == null) return axe;
+
+        meta.displayName(Component.text("Sign Axe", NamedTextColor.GRAY));
+        meta.lore(List.of(Component.text("Use signs to chat", NamedTextColor.DARK_GRAY)));
+        meta.setUnbreakable(true);
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE);
+        meta.getPersistentDataContainer().set(signModeItemKey, PersistentDataType.BYTE, (byte) 1);
+
+        axe.setItemMeta(meta);
+        List<BlockType> breakableSigns = new java.util.ArrayList<>();
+        for (Material mat : Material.values()) {
+            if (mat.isBlock() && mat.name().contains("SIGN")) {
+                breakableSigns.add(mat.asBlockType());
+            }
+        }
+
+        axe.setData(
+            DataComponentTypes.CAN_BREAK,
+            ItemAdventurePredicate.itemAdventurePredicate()
+                .addPredicate(
+                    BlockPredicate.predicate()
+                        .blocks(RegistrySet.keySetFromValues(RegistryKey.BLOCK, breakableSigns))
+                        .build()
+                )
+                .build()
+        );
+        return axe;
+    }
+
+    /**
+     * Creates a stack of 16 oak signs for use in sign mode.
+     * Sets an adventure-mode placement predicate for all non-air block materials
+     * so players can place them on any surface.
+     */
+    public ItemStack createSignStack() {
+        ItemStack signs = new ItemStack(Material.OAK_SIGN, SIGN_STACK_SIZE);
+        ItemMeta meta = signs.getItemMeta();
+        if (meta == null) return signs;
+
+        meta.displayName(Component.text("Sign (Chat)", NamedTextColor.GRAY));
+        meta.lore(List.of(Component.text("Place a sign to send a message", NamedTextColor.DARK_GRAY)));
+        meta.setUnbreakable(true);
+        meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_UNBREAKABLE, ItemFlag.HIDE_PLACED_ON);
+        meta.getPersistentDataContainer().set(signModeItemKey, PersistentDataType.BYTE, (byte) 1);
+
+        List<BlockType> placeableOn = new java.util.ArrayList<>();
+        for (Material mat : Material.values()) {
+            if (mat.isBlock() && !mat.isAir()) {
+                placeableOn.add(mat.asBlockType());
+            }
+        }
+
+        signs.setItemMeta(meta);
+        signs.setData(
+            DataComponentTypes.CAN_PLACE_ON,
+            ItemAdventurePredicate.itemAdventurePredicate()
+                .addPredicate(
+                    BlockPredicate.predicate()
+                        .blocks(RegistrySet.keySetFromValues(RegistryKey.BLOCK, placeableOn))
+                        .build()
+                )
+                .build()
+        );
+        return signs;
+    }
+
+    /**
+     * Returns {@code true} if the given item is a sign-mode item (axe or sign stack)
+     * created by this manager.
+     */
+    public boolean isSignModeItem(ItemStack item) {
+        if (item == null) return false;
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) return false;
+        return meta.getPersistentDataContainer().has(signModeItemKey, PersistentDataType.BYTE);
+    }
+
+    // -------------------------------------------------------------------------
+    // Item distribution
+    // -------------------------------------------------------------------------
+
+    /**
+     * Gives each player the sign-mode kit: axe in slot 0, two stacks of 16
+     * oak signs in slots 1 and 2.  Existing items in those hotbar slots are
+     * overwritten; items that are displaced are silently discarded because
+     * inventories are already cleared prior to this call.
+     *
+     * @param players the collection of alive players to receive sign items
+     */
+    public void giveSignItems(Collection<org.bukkit.entity.Player> players) {
+        if (players == null || players.isEmpty()) return;
+
+        ItemStack axe = createSignAxe();
+        ItemStack signs1 = createSignStack();
+        ItemStack signs2 = createSignStack();
+
+        for (org.bukkit.entity.Player player : players) {
+            if (player == null || !player.isOnline()) continue;
+            try {
+                player.getInventory().setItem(SIGN_AXE_SLOT, axe.clone());
+                player.getInventory().setItem(SIGN_STACK_1_SLOT, signs1.clone());
+                player.getInventory().setItem(SIGN_STACK_2_SLOT, signs2.clone());
+                player.updateInventory();
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to give sign items to " + player.getName() + ": " + e.getMessage());
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Placement tracking
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers a sign block that was placed by a player during an active session.
+     *
+     * @param sessionName the name of the session the sign belongs to
+     * @param location    the world location of the placed sign block
+     * @param placerId    the UUID of the player who placed the sign
+     */
+    public void registerSignPlacement(String sessionName, Location location, UUID placerId) {
+        if (sessionName == null || location == null || placerId == null) return;
+        Location key = toBlockKey(location);
+        sessionSigns
+            .computeIfAbsent(sessionName, k -> new ConcurrentHashMap<>())
+            .put(key, placerId);
+        plugin.getLogger().fine("Tracked sign at " + formatLoc(key) + " by " + placerId + " in session " + sessionName);
+    }
+
+    /**
+     * Removes a sign from the tracking map (e.g. when it is broken).
+     * This does NOT remove the block from the world; use
+     * {@link #clearSessionSigns(String)} for that.
+     *
+     * @param sessionName the session the sign belongs to
+     * @param location    the location of the sign block
+     */
+    public void removeSignTracking(String sessionName, Location location) {
+        if (sessionName == null || location == null) return;
+        Map<Location, UUID> signs = sessionSigns.get(sessionName);
+        if (signs != null) {
+            signs.remove(toBlockKey(location));
+        }
+    }
+
+    /**
+     * Returns {@code true} if the block at the given location was placed as a
+     * sign-mode sign during the specified session.
+     */
+    public boolean isTrackedSign(String sessionName, Location location) {
+        if (sessionName == null || location == null) return false;
+        Map<Location, UUID> signs = sessionSigns.get(sessionName);
+        return signs != null && signs.containsKey(toBlockKey(location));
+    }
+
+    /**
+     * Returns the UUID of the player who placed the sign at the given location,
+     * or {@code null} if the location is not tracked.
+     */
+    public UUID getSignPlacer(String sessionName, Location location) {
+        if (sessionName == null || location == null) return null;
+        Map<Location, UUID> signs = sessionSigns.get(sessionName);
+        return signs != null ? signs.get(toBlockKey(location)) : null;
+    }
+
+    /**
+     * Returns the number of signs currently tracked for the given session.
+     */
+    public int getSignCount(String sessionName) {
+        if (sessionName == null) return 0;
+        Map<Location, UUID> signs = sessionSigns.get(sessionName);
+        return signs != null ? signs.size() : 0;
+    }
+
+    // -------------------------------------------------------------------------
+    // World cleanup
+    // -------------------------------------------------------------------------
+
+    /**
+     * Removes all signs that were placed during the given session from both the
+     * world and the tracking map.  Called at the start of the discussion phase
+     * so the map is clean before players are teleported to the discussion area.
+     *
+     * @param sessionName the session whose signs should be cleared
+     */
+    public void clearSessionSigns(String sessionName) {
+        if (sessionName == null) return;
+
+        Map<Location, UUID> signs = sessionSigns.remove(sessionName);
+        if (signs == null || signs.isEmpty()) {
+            plugin.getLogger().info("No signs to clear for session: " + sessionName);
+            return;
+        }
+
+        int cleared = 0;
+        int skipped = 0;
+
+        for (Location loc : signs.keySet()) {
+            if (loc == null) {
+                skipped++;
+                continue;
+            }
+            World world = loc.getWorld();
+            if (world == null) {
+                skipped++;
+                continue;
+            }
+
+            try {
+                Block block = world.getBlockAt(loc);
+                String typeName = block.getType().name();
+                // Match any sign variant (OAK_SIGN, SPRUCE_WALL_SIGN, etc.)
+                if (typeName.contains("SIGN")) {
+                    block.setType(Material.AIR);
+                    cleared++;
+                } else {
+                    // Block is no longer a sign (already removed by other means)
+                    skipped++;
+                }
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to remove sign at " + formatLoc(loc) + " for session " + sessionName + ": " + e.getMessage());
+                skipped++;
+            }
+        }
+
+        plugin.getLogger().info("Sign cleanup for session '" + sessionName + "': removed=" + cleared + ", skipped=" + skipped);
+    }
+
+    /**
+     * Cleans up all tracked sessions.  Called on emergency shutdown.
+     */
+    public void clearAll() {
+        for (String sessionName : new HashSet<>(sessionSigns.keySet())) {
+            clearSessionSigns(sessionName);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Normalises a {@link Location} to integer block coordinates with yaw=0,
+     * pitch=0 so it can be used reliably as a map key.
+     */
+    private static Location toBlockKey(Location loc) {
+        return new Location(
+            loc.getWorld(),
+            loc.getBlockX(),
+            loc.getBlockY(),
+            loc.getBlockZ()
+        );
+    }
+
+    private static String formatLoc(Location loc) {
+        if (loc == null) return "null";
+        return (loc.getWorld() != null ? loc.getWorld().getName() : "?")
+            + " [" + loc.getBlockX() + "," + loc.getBlockY() + "," + loc.getBlockZ() + "]";
+    }
+}

--- a/src/main/java/com/ohacd/matchbox/game/utils/Managers/InventoryManager.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/Managers/InventoryManager.java
@@ -42,8 +42,8 @@ public class InventoryManager {
 
     private static NamespacedKey VOTE_TARGET_KEY;
     
-    // Track players who have used their arrow this round
-    private final Set<UUID> usedArrowThisRound = new HashSet<>();
+    // Track players who have used their arrow this round, keyed by session name
+    private final Map<String, Set<UUID>> usedArrowBySession = new HashMap<>();
     
     // Track voting papers (player UUID -> voting paper item)
     private final Map<UUID, ItemStack> votingPapers = new HashMap<>();
@@ -269,10 +269,12 @@ public class InventoryManager {
     }
     
     /**
-     * Resets arrow usage for a new round.
+     * Resets arrow usage for a new round for the given session.
      */
-    public void resetArrowUsage() {
-        usedArrowThisRound.clear();
+    public void resetArrowUsage(String sessionName) {
+        if (sessionName != null) {
+            usedArrowBySession.remove(sessionName);
+        }
     }
     
     /**
@@ -478,34 +480,35 @@ public class InventoryManager {
     }
     
     /**
-     * Marks that a player has used their arrow this round.
+     * Marks that a player has used their arrow this round in a given session.
      */
-    public void markArrowUsed(UUID playerId) {
-        if (playerId != null) {
-            usedArrowThisRound.add(playerId);
+    public void markArrowUsed(String sessionName, UUID playerId) {
+        if (sessionName != null && playerId != null) {
+            usedArrowBySession.computeIfAbsent(sessionName, k -> new HashSet<>()).add(playerId);
         }
     }
     
     /**
-     * Checks if a player has used their arrow this round.
+     * Checks if a player has used their arrow this round in a given session.
      */
-    public boolean hasUsedArrow(UUID playerId) {
-        if (playerId == null) {
+    public boolean hasUsedArrow(String sessionName, UUID playerId) {
+        if (sessionName == null || playerId == null) {
             return false;
         }
-        return usedArrowThisRound.contains(playerId);
+        Set<UUID> sessionSet = usedArrowBySession.get(sessionName);
+        return sessionSet != null && sessionSet.contains(playerId);
     }
     
     /**
      * Gives a new arrow to the player if they haven't used it this round.
      */
-    public void giveArrowIfNeeded(Player player) {
+    public void giveArrowIfNeeded(String sessionName, Player player) {
         if (player == null || !player.isOnline()) {
             return;
         }
         
         UUID playerId = player.getUniqueId();
-        if (hasUsedArrow(playerId)) {
+        if (hasUsedArrow(sessionName, playerId)) {
             return; // Already used arrow this round
         }
         

--- a/src/main/java/com/ohacd/matchbox/game/utils/listeners/BlockInteractionProtectionListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/listeners/BlockInteractionProtectionListener.java
@@ -1,6 +1,8 @@
 package com.ohacd.matchbox.game.utils.listeners;
 
 import com.ohacd.matchbox.game.GameManager;
+import com.ohacd.matchbox.game.SessionGameContext;
+import com.ohacd.matchbox.game.utils.GamePhase;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -9,6 +11,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
 
 /**
  * Prevents players from interacting with blocks during active games.
@@ -48,6 +51,25 @@ public class BlockInteractionProtectionListener implements Listener {
         // Block all block interactions (right-click on blocks, left-click on blocks)
         if (event.getAction() == Action.RIGHT_CLICK_BLOCK || event.getAction() == Action.LEFT_CLICK_BLOCK) {
             Block clickedBlock = event.getClickedBlock();
+
+            // Allow right-click sign placement in sign mode during SWIPE phase
+            if (event.getAction() == Action.RIGHT_CLICK_BLOCK
+                    && gameManager.isSignModeEnabled()
+                    && isInSwipePhase(player)
+                    && isHoldingSignModeSignItem(player)) {
+                return;
+            }
+
+            // Allow left-click sign breaking in sign mode during SWIPE phase
+            if (event.getAction() == Action.LEFT_CLICK_BLOCK
+                    && gameManager.isSignModeEnabled()
+                    && isInSwipePhase(player)
+                    && clickedBlock != null
+                    && clickedBlock.getType().name().contains("SIGN")
+                    && isHoldingSignModeAxe(player)) {
+                return;
+            }
+
             if (clickedBlock != null) {
                 // Specifically prevent flower pot interactions to avoid duplication bug
                 Material blockType = clickedBlock.getType();
@@ -92,12 +114,43 @@ public class BlockInteractionProtectionListener implements Listener {
             return false;
         }
 
-        com.ohacd.matchbox.game.SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
+        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
         if (context == null) {
             return false;
         }
 
         return context.getGameState().isGameActive();
+    }
+
+    /**
+     * Returns {@code true} if the player is currently in the SWIPE phase.
+     */
+    private boolean isInSwipePhase(Player player) {
+        SessionGameContext context = gameManager.getContextForPlayer(player.getUniqueId());
+        if (context == null) return false;
+        return context.getPhaseManager().getCurrentPhase() == GamePhase.SWIPE;
+    }
+
+    /**
+     * Returns {@code true} if the item held in the player's main hand is a
+     * sign-mode sign item (i.e. an OAK_SIGN marked as a game item via the
+     * sign-mode PDC tag).
+     */
+    private boolean isHoldingSignModeSignItem(Player player) {
+        ItemStack held = player.getInventory().getItemInMainHand();
+        if (held == null || held.getType() == Material.AIR) return false;
+        // Delegate to SignModeManager via GameManager
+        return gameManager.isSignModeItem(held);
+    }
+
+    /**
+     * Returns {@code true} if the item held in the player's main hand is the
+     * sign-mode wooden axe.
+     */
+    private boolean isHoldingSignModeAxe(Player player) {
+        ItemStack held = player.getInventory().getItemInMainHand();
+        if (held == null || held.getType() != Material.WOODEN_AXE) return false;
+        return gameManager.isSignModeItem(held);
     }
 }
 

--- a/src/main/java/com/ohacd/matchbox/game/utils/listeners/HitRevealListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/listeners/HitRevealListener.java
@@ -53,7 +53,7 @@ public class HitRevealListener implements Listener {
         }
         
         // Check if shooter has used their arrow this round
-        if (inventoryManager.hasUsedArrow(shooter.getUniqueId())) {
+        if (inventoryManager.hasUsedArrow(context.getSessionName(), shooter.getUniqueId())) {
             return; // Already used arrow this round
         }
         
@@ -68,7 +68,7 @@ public class HitRevealListener implements Listener {
         }
         
         // Mark arrow as used
-        inventoryManager.markArrowUsed(shooter.getUniqueId());
+        inventoryManager.markArrowUsed(context.getSessionName(), shooter.getUniqueId());
         
         // Reveal player identity for 10 seconds (200 ticks)
         hologramManager.showTextAbove(target, com.ohacd.matchbox.game.utils.PlayerNameUtils.displayName(target), 200);

--- a/src/main/java/com/ohacd/matchbox/game/utils/listeners/PlayerJoinListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/listeners/PlayerJoinListener.java
@@ -30,45 +30,49 @@ public class PlayerJoinListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
-        
-        // Show title welcome message
-        Component title = Component.text("§6§lWelcome to Matchbox!");
-        Component subtitle = Component.text("§7A Social Deduction Game for Minecraft");
-        
-        Title welcomeTitle = Title.title(
-            title,
-            subtitle,
-            Title.Times.times(
-                Duration.ofMillis(500),  // fade in
-                Duration.ofSeconds(3),    // stay
-                Duration.ofMillis(500)   // fade out
-            )
-        );
-        
-        player.showTitle(welcomeTitle);
-        
-        // Send welcome message after a short delay
-        plugin.getServer().getScheduler().runTaskLater(
-            plugin,
-            () -> {
-                if (player.isOnline()) {
-                    player.sendMessage("§6§l━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-                    player.sendMessage("§e§lMatchbox §7- Social Deduction Game");
-                    player.sendMessage("");
-                    player.sendMessage("§7Matchbox is a §e7-player social deduction game §7where");
-                    player.sendMessage("§7players must work together to identify the §cSpark §7(impostor)");
-                    player.sendMessage("§7while the Spark tries to eliminate everyone.");
-                    player.sendMessage("");
-                    player.sendMessage("§7Current Version: §e" + currentVersion + " §7(" + updateName + ")");
-                    player.sendMessage("§7Status: §d" + projectStatus); // " §7- Ready for gameplay"
-                    player.sendMessage("");
-                    player.sendMessage("§7Found a bug or have suggestions?");
-                    player.sendMessage("§7Join our Discord: §9§nhttps://discord.gg/BTDP3APfq8");
-                    player.sendMessage("§6§l━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-                }
-            },
-            40L // 2 seconds delay (20 ticks = 1 second)
-        );
+
+        boolean joinMessageEnabled = plugin.getConfig().getBoolean("join-message.enabled", false);
+
+        if (joinMessageEnabled) {
+            // Show title welcome message
+            Component title = Component.text("§6§lWelcome to Matchbox!");
+            Component subtitle = Component.text("§7A Social Deduction Game for Minecraft");
+            
+            Title welcomeTitle = Title.title(
+                title,
+                subtitle,
+                Title.Times.times(
+                    Duration.ofMillis(500),  // fade in
+                    Duration.ofSeconds(3),    // stay
+                    Duration.ofMillis(500)   // fade out
+                )
+            );
+            
+            player.showTitle(welcomeTitle);
+            
+            // Send welcome message after a short delay
+            plugin.getServer().getScheduler().runTaskLater(
+                plugin,
+                () -> {
+                    if (player.isOnline()) {
+                        player.sendMessage("§6§l━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+                        player.sendMessage("§e§lMatchbox §7- Social Deduction Game");
+                        player.sendMessage("");
+                        player.sendMessage("§7Matchbox is a §e7-player social deduction game §7where");
+                        player.sendMessage("§7players must work together to identify the §cSpark §7(impostor)");
+                        player.sendMessage("§7while the Spark tries to eliminate everyone.");
+                        player.sendMessage("");
+                        player.sendMessage("§7Current Version: §e" + currentVersion + " §7(" + updateName + ")");
+                        player.sendMessage("§7Status: §d" + projectStatus); // " §7- Ready for gameplay"
+                        player.sendMessage("");
+                        player.sendMessage("§7Found a bug or have suggestions?");
+                        player.sendMessage("§7Join our Discord: §9§nhttps://discord.gg/BTDP3APfq8");
+                        player.sendMessage("§6§l━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+                    }
+                },
+                40L // 2 seconds delay (20 ticks = 1 second)
+            );
+        }
 
         // Checks the version that the player is running against the latest project version and notify the player
         plugin.getServer().getScheduler().runTaskLater(

--- a/src/main/java/com/ohacd/matchbox/game/utils/listeners/PlayerQuitListener.java
+++ b/src/main/java/com/ohacd/matchbox/game/utils/listeners/PlayerQuitListener.java
@@ -38,6 +38,7 @@ public class PlayerQuitListener implements Listener {
         String sessionName = context.getSessionName();
         GameState gameState = context.getGameState();
 
+        gameManager.restorePlayerNick(player);
         NameTagManager.showNameTag(player);
         gameManager.getSkinManager().restoreOriginalSkin(player);
         gameManager.getHunterVisionAdapter().stopVision(playerId);

--- a/src/main/java/com/ohacd/matchbox/game/win/WinConditionChecker.java
+++ b/src/main/java/com/ohacd/matchbox/game/win/WinConditionChecker.java
@@ -27,7 +27,18 @@ public class WinConditionChecker {
         if (sparkPlayer != null && sparkPlayer.isOnline()) {
             return sparkPlayer.getName();
         }
-        // Fallback: try to get name from offline player or return UUID string
+        // Fallback: use last-known name from offline player data
+        try {
+            org.bukkit.OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(sparkUUID);
+            if (offlinePlayer != null) {
+                String offlineName = offlinePlayer.getName();
+                if (offlineName != null) {
+                    return offlineName;
+                }
+            }
+        } catch (Exception ignored) {
+            // If offline player lookup fails, fall through to UUID string
+        }
         return sparkUUID.toString();
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -11,55 +11,55 @@ session:
   # Minimum number of spawn locations required before starting a game
   min-spawn-locations: 1
   spawn-locations:
-  - world: m4tchb0x
+  - world: m4tchbox
     x: -51.473426361396264
     y: -28.0
     z: 62.99461190591391
     pitch: 0.69033235
     yaw: 0.1887207
-  - world: m4tchb0x
+  - world: m4tchbox
     x: -150.17946738772446
     y: -28.0
     z: 56.40573214795135
     pitch: 5.9847145
     yaw: -29.963623
-  - world: m4tchb0x
+  - world: m4tchbox
     x: -148.54268372924275
     y: -28.0
     z: 157.59044118502777
     pitch: 0.69035906
     yaw: -92.0
-  - world: m4tchb0x
+  - world: m4tchbox
     x: -51.739567395775154
     y: -28.0
     z: 255.41098517125434
     pitch: 4.488498
     yaw: -177.7445
-  - world: m4tchb0x
+  - world: m4tchbox
     x: -4.691513152574944
     y: -28.0
     z: 208.96547601851555
     pitch: 4.258306
     yaw: 90.31067
-  - world: m4tchb0x
+  - world: m4tchbox
     x: 34.49659508040274
     y: -28.0
     z: 156.4157398922256
     pitch: 6.560222
     yaw: 90.77466
-  - world: m4tchb0x
+  - world: m4tchbox
     x: -0.5183775312148339
     y: -28.0
     z: 113.5868217210009
     pitch: 3.1073725
     yaw: 1.0196533
-  - world: m4tchb0x
+  - world: m4tchbox
     x: 34.3062856383851
     y: -28.0
     z: 98.9279350023729
     pitch: 5.1790857
     yaw: 6.4093018
-  - world: m4tchb0x
+  - world: m4tchbox
     x: 12.167055671992346
     y: -28.0
     z: 70.27321679178925
@@ -73,6 +73,15 @@ session:
 #   z: 0.5
 #   yaw: 0.0
 #   pitch: 0.0
+
+# Sign Mode Settings
+# When enabled, players receive a wooden axe and two stacks of oak signs at the start
+# of the swipe phase. Placing a sign broadcasts its text to all alive players as
+# in-game chat, replacing the normal hologram-based chat for that message.
+# Placed signs are automatically removed from the world when discussion starts.
+sign-mode:
+  # Whether sign mode is enabled (default: true)
+  enabled: true
 
 # Swipe Phase Settings
 swipe:
@@ -114,56 +123,56 @@ discussion:
   duration: 60
   seat-locations:
     '1':
-      world: m4tchb0x
+      world: m4tchbox
       x: -129.16343439943907
       y: -26.5
       z: 251.55774675779458
       yaw: -89.37445
       pitch: 1.611053
     '2':
-      world: m4tchb0x
+      world: m4tchbox
       x: -129.1864844318363
       y: -26.5
       z: 254.36611360150775
       yaw: -90.75531
       pitch: 1.7261552
     '3':
-      world: m4tchb0x
+      world: m4tchbox
       x: -125.52719780180495
       y: -26.5
       z: 257.0771164995616
       yaw: 179.12561
       pitch: 4.143142
     '4':
-      world: m4tchb0x
+      world: m4tchbox
       x: -122.25339360180097
       y: -26.5
       z: 257.0268930333515
       yaw: 179.12561
       pitch: 4.143142
     '5':
-      world: m4tchb0x
+      world: m4tchbox
       x: -119.0030134337861
       y: -26.5
       z: 254.59310772635314
       yaw: 90.84845
       pitch: 1.265751
     '6':
-      world: m4tchb0x
+      world: m4tchbox
       x: -118.96102588929145
       y: -26.5
       z: 251.74950939174357
       yaw: 90.84845
       pitch: 1.265751
     '7':
-      world: m4tchb0x
+      world: m4tchbox
       x: -122.2330839151841
       y: -26.5
       z: 248.93487004108408
       yaw: 1.9953613
       pitch: 0.11480462
     '8':
-      world: m4tchb0x
+      world: m4tchbox
       x: -125.51700092500927
       y: -26.5
       z: 248.82053637494593
@@ -205,6 +214,12 @@ voting:
     max-phases: 3
     # Maximum penalty reduction percentage (0.10 = 10%)
     max-reduction: 0.1
+
+# Join Message Settings
+join-message:
+  # Whether to show the welcome message and title to players when they join the server (default: false)
+  # The update notification message is always shown regardless of this setting
+  enabled: false
 
 # Cosmetic Settings
 cosmetics:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Matchbox
 version: '${version}'
 main: com.ohacd.matchbox.Matchbox
-api-version: '1.21.10'
+api-version: '1.21.11'
 authors: [ OhACD ]
 description: A Minecraft Social Minigame
 softdepend: [ ProtocolLib ]

--- a/src/test/java/com/ohacd/matchbox/utils/MockBukkitFactory.java
+++ b/src/test/java/com/ohacd/matchbox/utils/MockBukkitFactory.java
@@ -132,7 +132,7 @@ public class MockBukkitFactory {
     public static Server createMockServer() {
         Server server = mock(Server.class);
         when(server.getLogger()).thenReturn(Logger.getAnonymousLogger());
-        when(server.getBukkitVersion()).thenReturn("1.21.10-R0.1-SNAPSHOT");
+        when(server.getBukkitVersion()).thenReturn("1.21.11-R0.1-SNAPSHOT");
 
         // Mock Scheduler
         BukkitScheduler scheduler = mock(BukkitScheduler.class);

--- a/wiki-pages/Developer-Notes.md
+++ b/wiki-pages/Developer-Notes.md
@@ -119,7 +119,7 @@ See [Contributing](Contributing) for more details.
 - **Development Policy**: `DEVELOPMENT_POLICY.md` (in repository)
 
 ### External Dependencies
-- **Paper API**: MC 1.21.10 (build against latest)
+- **Paper API**: MC 1.21.11 (build against latest)
 - **ProtocolLib**: 5.4.0+ (for Hunter Vision packet manipulation)
 
 ### Useful Links

--- a/wiki-pages/FAQ.md
+++ b/wiki-pages/FAQ.md
@@ -4,7 +4,7 @@
 
 ### Q: What are the requirements to run Matchbox?
 **A:** You need:
-- Paper server 1.21.10 or higher
+- Paper server 1.21.11 or higher
 - Java 21 or higher
 - ProtocolLib 5.4.0 or higher
 - The M4tchb0x map (optional but recommended)
@@ -72,7 +72,7 @@ Player permissions:
 
 ### Q: The plugin isn't loading
 **A:** Check:
-1. You're running Paper 1.21.10+ (not Spigot or Bukkit)
+1. You're running Paper 1.21.11+ (not Spigot or Bukkit)
 2. You have Java 21 or higher
 3. Check server logs for error messages
 

--- a/wiki-pages/Getting-Started.md
+++ b/wiki-pages/Getting-Started.md
@@ -6,7 +6,7 @@ This guide will help you install and set up Matchbox on your server.
 
 Before you begin, make sure you have:
 
-- **Minecraft Server**: Paper 1.21.10 or higher ([Download Paper](https://papermc.io/downloads))
+- **Minecraft Server**: Paper 1.21.11 or higher ([Download Paper](https://papermc.io/downloads))
 - **Java**: Version 21 or higher
 - **Dependencies**: ProtocolLib 5.4.0 or higher ([Download](https://www.spigotmc.org/resources/protocollib.1997/))
 - **Map** (Optional): M4tchb0x official map ([Download](https://www.planetminecraft.com/project/m4tchb0x-maps/))

--- a/wiki-pages/Home.md
+++ b/wiki-pages/Home.md
@@ -18,7 +18,7 @@ One player is secretly the **Spark** (impostor). Everyone else must identify and
 
 ## Requirements
 
-- **Server**: Paper 1.21.10+
+- **Server**: Paper 1.21.11+
 - **Java**: 21+
 - **Dependencies**: ProtocolLib 5.4.0+
 - **Players**: 2–20 per game (best with 5–9)
@@ -31,6 +31,6 @@ One player is secretly the **Spark** (impostor). Everyone else must identify and
 
 ## Description
 
-A lightweight minigame plugin for Paper (1.21.10+). Matchbox is a recording-proof social deduction game inspired by Among Us, designed for multiplayer servers with session-based gameplay and full configuration support.
+A lightweight minigame plugin for Paper (1.21.11+). Matchbox is a recording-proof social deduction game inspired by Among Us, designed for multiplayer servers with session-based gameplay and full configuration support.
 
 Use `plugins/Matchbox/config.yml` for configuration and see this wiki for usage and developer notes.


### PR DESCRIPTION
## [0.9.6] - Development (Nick System, Sign Mode, Skin & Stability)

Players can now compete under custom nicknames, communicate via signs during the swipe phase, and benefit from a more consistent and reliable game experience.

### Nick System

- **Set a nick** — pick any name (3–16 characters, letters/numbers/`_`/`-`) and it becomes your identity for the duration of the game. Your nick shows in chat, the player list, and above your head.
- **Random nick** — generates a realistic-looking username from a curated word list in styles like `FrostWolf`, `frost_wolf`, `FROST_Wolf`, or `frostWolf`. A numeric suffix is added automatically if the generated name is already taken.
- **Session-scoped** — nicks activate when a game starts and are removed the moment the game ends, you leave, or you disconnect. No carry-over between games.
- **Unique per session** — no two players in the same game can share a nick. The second player to claim a taken nick is blocked and told to pick another.
- **Persistent preference** — your chosen nick is saved across restarts. You only need to set it once.
- **Action bar reminder** — while outside a game, a subtle `Currently Nicked as: [Nick]` message sits above your hotbar so you always know what name you're carrying.
- **Admins** (`matchbox.admin`) can set, randomise, or reset any player's nick.

| Command | Who | What it does |
|---|---|---|
| `/mb nick` | anyone | See your current nick |
| `/mb nick <name>` | anyone | Set your nick |
| `/mb nick random` | anyone | Get a randomly generated nick |
| `/mb nick reset` | anyone | Remove your nick |
| `/mb nick <player> <name>` | admin | Set another player's nick |
| `/mb nick reset <player>` | admin | Remove another player's nick |
| `/mb nick random <player>` | admin | Generate a random nick for another player |

### Sign Mode

- **Signs as communication** — when `sign-mode.enabled: true`, players communicate by placing signs during the swipe phase instead of typing in chat. Each player receives a sign kit at the start of swipe.
- **Automatic cleanup** — all placed signs are removed when discussion begins or the game ends. Nothing is left behind in the world.
- **Chat bypass** — normal in-game chat is suppressed when sign mode is on, so signs are the only intended channel.
- **Join message toggle** (`join-message.enabled`) — server owners can disable the welcome title/message shown on join without affecting version notifications.

### Skin & Visual Changes

- Skin rendering upgraded to use ProtocolLib player-info packet rewrites for more consistent updates across clients.
- Steve fallback improved — when skin lookups fail (offline mode or API unavailable), all players receive a consistent classic Steve skin rather than a mix of random fallbacks.
- Paper compatibility raised to **1.21.11**.

### Bug Fixes

- **Eliminated players no longer appear in game chat** — they were being cached as alive in the chat pipeline after death. The cache is now cleared on elimination.
- **Arrow tracking is now per-session** — a round reset in one game no longer clears arrow-used state for players in a different concurrent session.
- **Players with failed state backups are excluded from the game** — previously, if saving a player's inventory or location failed, they were still added to the alive roster and couldn't be restored at game end.
- **Win screen shows the Spark's name, not their UUID** — when the Spark disconnects and the game ends, the win announcement now resolves their name correctly.
- **Delusion decay timer now cancels on session end** — the 30-second task scheduled when Delusion was used was not being tracked. It is now cancelled alongside other session tasks on cleanup.
- **Random skin preloading no longer silently fails** — UUID format issues during cached skin loading are handled correctly.
- **Hologram cleanup is safe during shutdown** — no new scheduler tasks are created while the plugin is disabling.
- **Session player limit fixed** — min/max validation now correctly accepts the full `2–20` range.
- **Default spawn world corrected** — default config now references `m4tchbox` instead of the old typo `m4tchb0x`.
